### PR TITLE
Fixed issues #63 and #64

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -42,9 +42,33 @@ code {
 .market-loader {
     width: 80px;
     margin: auto;
-    position: absolute;
-    top: -60px; /* To negate the footer height to make it visually centered */
+    position: relative;
+}
+.page-loader {
+    width: 80px;
+    margin: auto;
+    position: absolute; /* To negate the footer height to make it visually centered */
+    top: -60px;
     left: 0; 
     bottom: 0; 
     right: 0;
 }
+
+.ant-popover {
+    max-width: 350px;
+    line-height: 25px;    
+    font-size: 13px;
+    font-weight: 500;
+}
+.ant-popover-title {
+    background-color: #f7f6f6;
+}
+
+
+/* Mobile screens */
+@media only screen and (max-width: 40em) {
+    .page {
+        padding: 40px;
+        margin: 0;
+    }
+} 

--- a/src/Splash.js
+++ b/src/Splash.js
@@ -5,7 +5,7 @@ import splashAnimation from './animations/splash.gif';
 class Splash extends Component {
   render() {
     return (
-      <img src={splashAnimation} alt={this.props.alt} className="market-loader"/>
+      <img src={splashAnimation} alt={this.props.alt} className="page-loader"/>
     );
   }
 }

--- a/src/components/ContractsList.js
+++ b/src/components/ContractsList.js
@@ -201,7 +201,7 @@ class ContractsList extends Component {
 
     if (!this.state.contracts) {
       return (
-        <Loader loading showInCenterOfPage/>
+        <Loader loading center/>
       );
     }
 

--- a/src/components/ContractsList.js
+++ b/src/components/ContractsList.js
@@ -201,7 +201,7 @@ class ContractsList extends Component {
 
     if (!this.state.contracts) {
       return (
-        <Loader loading/>
+        <Loader loading showInCenterOfPage/>
       );
     }
 

--- a/src/components/ContractsList.js
+++ b/src/components/ContractsList.js
@@ -201,7 +201,7 @@ class ContractsList extends Component {
 
     if (!this.state.contracts) {
       return (
-        <Loader loading center/>
+        <Loader loading={true} center={true}/>
       );
     }
 

--- a/src/components/DeployContract/DeployContractField.js
+++ b/src/components/DeployContract/DeployContractField.js
@@ -1,4 +1,4 @@
-import { DatePicker, Form, Icon, Input, InputNumber, Select, Tooltip } from 'antd';
+import { DatePicker, Form, Icon, Input, InputNumber, Select, Popover } from 'antd';
 import moment from 'moment';
 import React from 'react';
 
@@ -47,9 +47,10 @@ const oracleQueryValidator = (form, rule, value, callback) => {
   }
 };
 
-const Hint = (props) => (<Tooltip title={props.hint} >
-                          <Icon type="question-circle-o" />
-                        </Tooltip>);
+
+const Hint = (props) => (<Popover content={props.hint} title={"More about `" + props.hintTitle + "`"} trigger="click">
+                          <Icon type="question-circle-o" style={{cursor: 'pointer'}} />
+                        </Popover>);
 
 const fieldSettingsByName = {
   contractName: {
@@ -266,7 +267,7 @@ function DeployContractField(props) {
   const fieldSettings = fieldSettingsByName[name];
 
   const rules = typeof fieldSettings.rules === 'function' ? fieldSettings.rules(form) : fieldSettings.rules;
-  const label = (<span>{fieldSettings.label} {showHint && <Hint hint={fieldSettings.extra}/>}</span>);
+  const label = (<span>{fieldSettings.label} {showHint && <Hint hint={fieldSettings.extra} hintTitle= {fieldSettings.label}/>}</span>);
   return (
     <FormItem
       label={label}

--- a/src/components/DeployContract/QuickDeployment.js
+++ b/src/components/DeployContract/QuickDeployment.js
@@ -122,21 +122,21 @@ class QuickDeployment extends Component {
 
             <ContractFormRow>
               <ContractFormCol>
-                <Field name='priceFloor' initialValue={parseInt(initialValues.priceFloor, 10) ? parseInt(initialValues.priceFloor, 10) : ''} form={this.props.form} showHint/>
+                <Field name='priceFloor' initialValue={isNaN(initialValues.priceFloor) ? '' : parseInt(initialValues.priceFloor, 10)} form={this.props.form} showHint/>
               </ContractFormCol>
 
               <ContractFormCol>
-                <Field name='priceCap' initialValue={parseInt(initialValues.priceCap, 10) ? parseInt(initialValues.priceCap, 10) : '' } form={this.props.form} showHint/>
+                <Field name='priceCap' initialValue={isNaN(initialValues.priceCap) ? '' : parseInt(initialValues.priceCap, 10)} form={this.props.form} showHint/>
               </ContractFormCol>
             </ContractFormRow>
 
             <ContractFormRow>
               <ContractFormCol>
-                <Field name='priceDecimalPlaces' initialValue={parseInt(initialValues.priceDecimalPlaces, 10) ? parseInt(initialValues.priceDecimalPlaces, 10) : ''} form={this.props.form} showHint/>
+                <Field name='priceDecimalPlaces' initialValue={isNaN(initialValues.priceDecimalPlaces) ? '' : parseInt(initialValues.priceDecimalPlaces, 10)} form={this.props.form} showHint/>
               </ContractFormCol>
 
               <ContractFormCol>
-                <Field name="qtyMultiplier" initialValue={parseInt(initialValues.qtyMultiplier, 10) ? parseInt(initialValues.qtyMultiplier, 10): ''} form={this.props.form} showHint/>
+                <Field name="qtyMultiplier" initialValue={isNaN(initialValues.qtyMultiplier) ? '' : parseInt(initialValues.qtyMultiplier, 10)} form={this.props.form} showHint/>
               </ContractFormCol>
             </ContractFormRow>
 
@@ -156,7 +156,7 @@ class QuickDeployment extends Component {
               </ContractFormCol>
 
               <ContractFormCol>
-                <Field name='oracleQueryRepeatSeconds' initialValue={parseInt(initialValues.oracleQueryRepeatSeconds, 10)} form={this.props.form} showHint/>
+                <Field name='oracleQueryRepeatSeconds' initialValue={isNaN(initialValues.oracleQueryRepeatSeconds) ? '' : parseInt(initialValues.oracleQueryRepeatSeconds, 10)} form={this.props.form} showHint/>
               </ContractFormCol>
             </ContractFormRow>
 

--- a/src/components/DeployContract/QuickDeployment.js
+++ b/src/components/DeployContract/QuickDeployment.js
@@ -122,21 +122,21 @@ class QuickDeployment extends Component {
 
             <ContractFormRow>
               <ContractFormCol>
-                <Field name='priceFloor' initialValue={parseInt(initialValues.priceFloor, 10)} form={this.props.form} showHint/>
+                <Field name='priceFloor' initialValue={parseInt(initialValues.priceFloor, 10) ? parseInt(initialValues.priceFloor, 10) : ''} form={this.props.form} showHint/>
               </ContractFormCol>
 
               <ContractFormCol>
-                <Field name='priceCap' initialValue={parseInt(initialValues.priceCap, 10)} form={this.props.form} showHint/>
+                <Field name='priceCap' initialValue={parseInt(initialValues.priceCap, 10) ? parseInt(initialValues.priceCap, 10) : '' } form={this.props.form} showHint/>
               </ContractFormCol>
             </ContractFormRow>
 
             <ContractFormRow>
               <ContractFormCol>
-                <Field name='priceDecimalPlaces' initialValue={parseInt(initialValues.priceDecimalPlaces, 10)} form={this.props.form} showHint/>
+                <Field name='priceDecimalPlaces' initialValue={parseInt(initialValues.priceDecimalPlaces, 10) ? parseInt(initialValues.priceDecimalPlaces, 10) : ''} form={this.props.form} showHint/>
               </ContractFormCol>
 
               <ContractFormCol>
-                <Field name="qtyMultiplier" initialValue={parseInt(initialValues.qtyMultiplier, 10)} form={this.props.form} showHint/>
+                <Field name="qtyMultiplier" initialValue={parseInt(initialValues.qtyMultiplier, 10) ? parseInt(initialValues.qtyMultiplier, 10): ''} form={this.props.form} showHint/>
               </ContractFormCol>
             </ContractFormRow>
 
@@ -176,7 +176,7 @@ class QuickDeployment extends Component {
               </Col>
             </Row>
 
-            <Loader loading={this.props.loading} />
+            <Loader loading={this.props.loading} showInCenterOfPage />
           </Form>
         </div>
       </div>

--- a/src/components/DeployContract/QuickDeployment.js
+++ b/src/components/DeployContract/QuickDeployment.js
@@ -176,7 +176,7 @@ class QuickDeployment extends Component {
               </Col>
             </Row>
 
-            <Loader loading={this.props.loading} showInCenterOfPage />
+            <Loader loading={this.props.loading} center/>
           </Form>
         </div>
       </div>

--- a/src/components/DeployContract/QuickDeployment.js
+++ b/src/components/DeployContract/QuickDeployment.js
@@ -176,7 +176,7 @@ class QuickDeployment extends Component {
               </Col>
             </Row>
 
-            <Loader loading={this.props.loading} center/>
+            <Loader loading={this.props.loading} center={true}/>
           </Form>
         </div>
       </div>

--- a/src/components/FindContract/FindContractForm.js
+++ b/src/components/FindContract/FindContractForm.js
@@ -97,7 +97,7 @@ class FindContractForm extends Component {
             </Button>
           </Col>
         </Row>
-        <Loader loading={this.props.loading} showInCenterOfPage/>
+        <Loader loading={this.props.loading} center/>
       </Form>
       <br />
       { this.props.contract.length > 0 &&

--- a/src/components/FindContract/FindContractForm.js
+++ b/src/components/FindContract/FindContractForm.js
@@ -97,7 +97,7 @@ class FindContractForm extends Component {
             </Button>
           </Col>
         </Row>
-        <Loader loading={this.props.loading} center/>
+        <Loader loading={this.props.loading} center={true}/>
       </Form>
       <br />
       { this.props.contract.length > 0 &&

--- a/src/components/FindContract/FindContractForm.js
+++ b/src/components/FindContract/FindContractForm.js
@@ -97,7 +97,7 @@ class FindContractForm extends Component {
             </Button>
           </Col>
         </Row>
-        <Loader loading={this.props.loading}/>
+        <Loader loading={this.props.loading} showInCenterOfPage/>
       </Form>
       <br />
       { this.props.contract.length > 0 &&

--- a/src/components/Landing.css
+++ b/src/components/Landing.css
@@ -1,6 +1,5 @@
 .hero {
   background: #3A3A3A url('../img/hero-pattern.svg') repeat;
-  /* background: #3A3A3A; */
   height: 650px;
 }
 .hero-text {
@@ -54,6 +53,7 @@
 
 .feature-sub-text {
   margin-bottom: 30px;
+  opacity: 0.5;
 }
 
 #test-section, #simulated-section {
@@ -62,4 +62,48 @@
 
 #test-section .feature-image, #simulated-section .feature-image {
   margin-top: -10px;
+}
+
+
+/* Only mobile screens */
+@media only screen and (max-width: 480px) {
+  .feature-text-container {
+    padding: 0 20px;
+  }
+}
+
+/* Mobile & tablet screens */
+@media only screen and (max-width: 768px) { 
+  .hide-mobile {
+    display: none;
+  }
+  #explore-section .feature-text-container {
+    text-align: right;
+  }
+  #test-section .feature-text-container {
+    text-align: left;
+  }
+  #simulated-section .feature-text-container {
+    text-align: right;
+  }
+  #test-section, #simulated-section {
+    margin-top: 0;
+  }
+  .feature-section {
+    padding-bottom: 40px;
+  }
+}
+
+/* Only tablet screens */
+@media only screen and (min-width: 480px) and (max-width: 1024px) { 
+  .feature-text-container {
+    padding: 0 50px;
+  }
+}
+
+/* Medium screens */
+@media only screen and (min-width: 768px) and (max-width: 1024px) { 
+  #test-section, #simulated-section {
+    margin-top: 0;
+  }
 }

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -18,26 +18,26 @@ class Landing extends Component {
     return (
       <div style={{backgroundColor: '#fff'}}>
         <Row type="flex" className="hero" align="middle">
-          <Col span={10}>
+          <Col xs={20} sm={20} md={10} lg={10} xl={10}>
             <div className="hero-text">
               <h1>Guided Contract Deployment</h1>
               <h4>Step by step guide for first time MARKET Smart Contract deployment</h4>
               <Button type="primary" size="large"><a href="/contract/deploy?mode=guided">Get Started <Icon type="right" /></a></Button>
             </div>
           </Col>
-          <Col span={14}>
+          <Col span={14} className="hide-mobile">
             <div className="hero-image">
               <img alt="Header Illustration" src={main} width="600"/>
             </div>
           </Col>
         </Row>
         <Row type="flex" align="middle" id="explore-section" className="feature-section">
-          <Col span={14}>
+          <Col xs={22} sm={22} md={14} lg={14} xl={14}>
             <div className="feature-image">
               <img alt="Explore contracts Illustration" src={explore} width="90%"/>
             </div>
           </Col>
-          <Col span={6}>
+          <Col xs={22} sm={22} md={10} lg={10} xl={6}>
             <div className="feature-text-container">
               <img alt="Explore contracts icons" className="feature-icons" src={exploreIcons}/>
               <h1 className="feature-main-text">Explore Contracts</h1>
@@ -46,8 +46,13 @@ class Landing extends Component {
             </div>
           </Col>
         </Row>
-        <Row type="flex" justify="end" align="middle" id="test-section" className="feature-section">
-          <Col span={6}>
+        <Row type="flex" align="middle" id="test-section" className="feature-section">
+          <Col xs={24} sm={24} md={{span: 14, push: 10}} lg={{span: 14, push: 10}} xl={{span: 14, push: 10}} style={{textAlign: 'right'}}>
+            <div className="feature-image">
+              <img alt="Test Queries Illustration" src={test} width="90%"/>
+            </div>
+          </Col>
+          <Col xs={24} sm={24} md={{span: 10, pull: 12}} lg={{span: 10, pull: 12}} xl={{span: 6, pull: 10}}>
             <div className="feature-text-container">
               <img alt="Test Queries icons" className="feature-icons" src={testIcons}/>
               <h1 className="feature-main-text">Test Queries</h1>
@@ -55,19 +60,14 @@ class Landing extends Component {
               <Button type="primary" size="large"><a href="/test">Get Started <Icon type="right" /></a></Button>
             </div>
           </Col>
-          <Col span={14} style={{textAlign: 'right'}}>
-            <div className="feature-image">
-              <img alt="Test Queries Illustration" src={test} width="90%"/>
-            </div>
-          </Col>
         </Row>
         <Row type="flex" align="middle" id="simulated-section" className="feature-section">
-          <Col span={14}>
+          <Col xs={22} sm={22} md={14} lg={14} xl={14}>
             <div className="feature-image">
               <img alt="Simulated exchange Illustration" src={simulate} width="90%"/>
             </div>
           </Col>
-          <Col span={6}>
+          <Col xs={22} sm={22} md={10} lg={10} xl={6}>
             <div className="feature-text-container">
               <img alt="Simulated exchange icons" className="feature-icons" src={simulateIcons}/>
               <h1 className="feature-main-text">Simulated Exchange</h1>

--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -8,7 +8,7 @@ function Loader(props) {
   };
 
   return (
-    <img alt="Market Loader" className="market-loader" src={splash} style={{ ...style }} />
+    <img alt="Market Loader" className={props.showInCenterOfPage ? 'page-loader' : 'market-loader'} src={splash} style={{ ...style }} />
   );
 }
 

--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -2,6 +2,11 @@ import React from 'react';
 
 import splash from '../animations/splash.gif';
 
+Loader.defaultProps  = {
+  loading: false,
+  center: false
+};
+
 function Loader(props) {
   const style = {
     display: props.loading ? 'flex' : 'none',

--- a/src/components/Loader.js
+++ b/src/components/Loader.js
@@ -8,7 +8,7 @@ function Loader(props) {
   };
 
   return (
-    <img alt="Market Loader" className={props.showInCenterOfPage ? 'page-loader' : 'market-loader'} src={splash} style={{ ...style }} />
+    <img alt="Market Loader" className={props.center ? 'page-loader' : 'market-loader'} src={splash} style={{ ...style }} />
   );
 }
 

--- a/test/components/Loader.test.js
+++ b/test/components/Loader.test.js
@@ -6,7 +6,7 @@ import Loader from '../../src/components/Loader';
 
 describe('Loader', () => {
   it('should be visible with loading set', () => {
-    const loader = mount(<Loader loading/>);
+    const loader = mount(<Loader loading={true}/>);
     expect(loader.find('div').prop('style').display).to.not.equal('none');
   });
 


### PR DESCRIPTION
- Added ‘showInCenterOfPage’ props to place the loader in centre of page
- Replaced tooltips with popovers in QuickDeploy page
- Fixed ‘NaN’ showing up in initial value of input fields in
QuickDeploy page