### PR TITLE
Fix for [General] "MetaMask is Locked" error message: Use async functions for accounts and network.

### DIFF
--- a/src/util/web3/getWeb3.js
+++ b/src/util/web3/getWeb3.js
@@ -38,23 +38,23 @@ let getWeb3 = (window,
     if (typeof web3 !== 'undefined' && web3.currentProvider && web3.currentProvider.isMetaMask) {
       console.log("Mist/MetaMask's detected!");
 
-      if (web3.eth.accounts.length === 0) { // check for unlocked metamask state
-        results = {
-          web3Instance: null,
-          network: 'unknown',
-        };
+      web3.eth.getAccounts((err, accounts) => {
+        if (accounts.length === 0) { // check for unlocked metamask state
+          results = {
+            web3Instance: null,
+            network: 'unknown',
+          };
 
         console.log("Please unlock MetaMask!");
 
         showErrorMessage('MetaMask is locked! Please unlock and refresh this page', 8);
         resolve(dispatch(web3Initialized(results)));
         return;
-      }
+      }});
 
-      if (typeof web3.version !== 'undefined') {
-        if (web3.version.network !== GANACHE &&
-          web3.version.network !== RINKEBY &&
-          web3.version.network !== TRUFFLE) { // ensure beta users don't spend real ether.
+      web3.version.getNetwork((error, network) => {
+        if (network !== RINKEBY &&
+          network !== TRUFFLE && network !== GANACHE) { // ensure beta users don't spend real ether.
 
           results = {
             web3Instance: null,
@@ -67,8 +67,7 @@ let getWeb3 = (window,
           resolve(dispatch(web3Initialized(results)));
           return;
         }
-      }
-
+      });
       web3 = new Web3(web3.currentProvider);
 
       results = {

--- a/src/util/web3/getWeb3.js
+++ b/src/util/web3/getWeb3.js
@@ -49,12 +49,10 @@ let getWeb3 = (window,
 
         showErrorMessage('MetaMask is locked! Please unlock and refresh this page', 8);
         resolve(dispatch(web3Initialized(results)));
-        return;
       }});
 
-      web3.version.getNetwork((error, network) => {
-        if (network !== RINKEBY &&
-          network !== TRUFFLE && network !== GANACHE) { // ensure beta users don't spend real ether.
+      const network = web3.version.getNetwork((error, network) => {
+        if (network !== RINKEBY && network !== TRUFFLE && network !== GANACHE) { // ensure beta users don't spend real ether.
 
           results = {
             web3Instance: null,
@@ -65,14 +63,13 @@ let getWeb3 = (window,
 
           showErrorMessage('Please select Rinkeby Test Network in MetaMask and then restart browser', 8);
           resolve(dispatch(web3Initialized(results)));
-          return;
-        }
+        } else return network;
       });
       web3 = new Web3(web3.currentProvider);
 
       results = {
         web3Instance: web3,
-        network: networkMap[web3.version.network] || 'unknown',
+        network: networkMap[network] || 'unknown',
       };
 
       console.log('Injected web3 detected.');

--- a/test/util/web3/getWeb3.test.js
+++ b/test/util/web3/getWeb3.test.js
@@ -20,50 +20,46 @@ describe('getWeb3', () => {
     };
   });
 
-  // helper to create a mock provider
-  function getMockProvider() {
-    const mockProvider = new FakeProvider();
-    mockProvider.isMetaMask = true;
-    // mockProvider.host = 'ws://remotenode.com:8546';
-    return mockProvider;
+  function mockedWeb3(callbackError = null, coinbaseAddress = '0x123456', accounts = ['0x0000001']) {
+    const fakeProvider = new FakeProvider();
+    const web3 = new Web3(fakeProvider);
+    fakeProvider.injectResult(accounts);
+    web3.eth.getCoinbase = (callback) => { callback(callbackError, coinbaseAddress); };
+    web3.eth.getAccounts = (callback) => { callback(callbackError, accounts); };
+    web3.eth.getNetwork = (callback) => { callback(callbackError, '4447'); };
+    web3.currentProvider.isMetaMask = true;
+    return web3;
   }
 
   // helper to setup window parameters
-  function setupWindow({ provider, accounts }) {
+  function setupWindow(web3Instance) {
     Object.assign(mockWindow, {
-      web3: {
-        currentProvider: provider,
-        eth: { accounts },
-      },
+      web3: web3Instance,
     });
   }
 
   it('should dispatch with web3.version.network as Truffle Develop Network', async () => {
-    const truffleDevelopNetworkId = '4447';
     const expectedNetwork = 'truffle';
-    const mockProvider = getMockProvider();
-    mockProvider.injectResult(truffleDevelopNetworkId);
-    setupWindow({ provider: mockProvider, accounts: [{}] });
-    
+
     await getWeb3(mockWindow, showErrorMessageSpy, dispatchSpy);
 
     const dispatchCall = dispatchSpy.getCall(0);
     const actualNetwork = dispatchCall.args[0].payload.network;
     expect(actualNetwork).to.equals(expectedNetwork);
   });
-  
+
   it('should fallback to default web3 provider if web3 provider does not exist', async () => {
     const defaultProviderHost = 'http://127.0.0.1:9545';
     await getWeb3(mockWindow, showErrorMessageSpy, dispatchSpy);
-    
+
     const dispatchCall = dispatchSpy.getCall(0);
     const web3Instance = dispatchCall.args[0].payload.web3Instance;
     expect(web3Instance.currentProvider.host).to.equals(defaultProviderHost);
   });
 
   it('should have proper results', async () => {
-    const mockProvider = getMockProvider();
-    setupWindow({ provider: mockProvider, accounts: [{}] }); // accounts must not be empty
+    const web3 = mockedWeb3();
+    setupWindow(web3); // accounts must not be empty
 
     await getWeb3(mockWindow, showErrorMessageSpy, dispatchSpy);
 
@@ -74,20 +70,20 @@ describe('getWeb3', () => {
     expect(payload).to.have.property('network');
   });
 
-  it('should dispatch web3.currentProvider as web3Instance', async () => {
-    const mockProvider = getMockProvider();
-    setupWindow({ provider: mockProvider, accounts: [{}] }); // accounts must not be empty
+  it('should dispatch web3 as web3Instance', async () => {
+    const web3 = mockedWeb3();
+    setupWindow(web3);
 
     await getWeb3(mockWindow, showErrorMessageSpy, dispatchSpy);
 
     const dispatchCall = dispatchSpy.getCall(0);
     const web3Instance = dispatchCall.args[0].payload.web3Instance;
-    expect(web3Instance.currentProvider).to.equals(mockProvider);
+    expect(web3Instance).to.have.property('currentProvider');
   });
 
   it('should show Error message when default provider is locked', async () => {
-    const mockProvider = getMockProvider();
-    setupWindow({ provider: mockProvider, accounts: [] }); // account is empty when locked
+    const web3 = mockedWeb3(null, '0x123456', []);
+    setupWindow(web3); // account is empty when locked
 
     await getWeb3(mockWindow, showErrorMessageSpy, dispatchSpy);
 


### PR DESCRIPTION
Fixes: #111


##### Description
Fixes MetaMask detection by using async versions of accounts and network.

##### Checklist

- [X] Linter status: 100% pass
- [X] Changes don't break existing behavior
- [X] Tests coverage hasn't decreased

##### Affected core subsystem(s)
web3 init

##### Testing
Tested manually.

##### Refers/Fixes
Fixes: #111 
