### PR TITLE
Fixes #116: actions/deploy,testQuery: Refine error messages.

### DIFF
--- a/src/actions/deploy.js
+++ b/src/actions/deploy.js
@@ -1,3 +1,4 @@
+import { dAppErrorMessage } from '../util/utils';
 
 /**
  *
@@ -88,8 +89,9 @@ export function deployContract(
               resolve(marketContractInstanceDeployed);
             })
             .catch(err => {
-              dispatch({ type: `${type}_REJECTED`, payload: err.message.split('\n')[0] });
-              reject(err.message.split('\n')[0]);
+              dispatch({ type: `${type}_REJECTED`,
+                         payload: dAppErrorMessage(err.message.split('\n')[0]) });
+              reject(dAppErrorMessage(err.message.split('\n')[0]));
             });
         });
       } else {

--- a/src/actions/deploy.js
+++ b/src/actions/deploy.js
@@ -1,4 +1,4 @@
-import { dAppErrorMessage } from '../util/utils';
+import { getMetamaskError } from '../util/utils';
 
 /**
  *
@@ -90,8 +90,8 @@ export function deployContract(
             })
             .catch(err => {
               dispatch({ type: `${type}_REJECTED`,
-                         payload: dAppErrorMessage(err.message.split('\n')[0]) });
-              reject(dAppErrorMessage(err.message.split('\n')[0]));
+                         payload: getMetamaskError(err.message.split('\n')[0]) });
+              reject(getMetamaskError(err.message.split('\n')[0]));
             });
         });
       } else {

--- a/src/actions/deploy.js
+++ b/src/actions/deploy.js
@@ -1,6 +1,6 @@
 
 /**
- * 
+ *
  * @param {web3} web3
  * @param {*} contractSpecs  Specs of new contract to be deployed
  * @param {*} MarketContractRegistry marketContractRegistryProvider
@@ -88,8 +88,8 @@ export function deployContract(
               resolve(marketContractInstanceDeployed);
             })
             .catch(err => {
-              dispatch({ type: `${type}_REJECTED`, payload: err });
-              reject(err);
+              dispatch({ type: `${type}_REJECTED`, payload: err.message.split('\n')[0] });
+              reject(err.message.split('\n')[0]);
             });
         });
       } else {

--- a/src/actions/testQuery.js
+++ b/src/actions/testQuery.js
@@ -1,3 +1,5 @@
+import { dAppErrorMessage } from '../util/utils';
+
 export function testQuery(
   { web3, querySpecs },
   { QueryTest }
@@ -13,8 +15,8 @@ export function testQuery(
         web3.eth.getCoinbase((error, coinbase) => {
           if (error) {
             console.error(error);
-            dispatch({ type: `${type}_REJECTED`, payload: error.message.split('\n')[0] });
-            return reject(error.message.split('\n')[0]);
+            dispatch({ type: `${type}_REJECTED`, payload: dAppErrorMessage(error.message.split('\n')[0]) });
+            return reject(dAppErrorMessage(error.message.split('\n')[0]));
           }
 
           console.log('Attempting to submit test query from ' + coinbase);
@@ -63,8 +65,8 @@ export function testQuery(
                         resolve(queryResults);
                       })
                       .catch(err => {
-                        dispatch({ type: `${type}_REJECTED`, payload: err.message.split('\n')[0] });
-                        reject(err.message.split('\n')[0]);
+                        dispatch({ type: `${type}_REJECTED`, payload: dAppErrorMessage(err.message.split('\n')[0]) });
+                        reject(dAppErrorMessage(err.message.split('\n')[0]));
                       });
                   }
                 });
@@ -72,8 +74,8 @@ export function testQuery(
             .catch(err => {
               // catch errors during query submission
               console.error(err);
-              dispatch({ type: `${type}_REJECTED`, payload: err.message.split('\n')[0] });
-              return reject(err.message.split('\n')[0]);
+              dispatch({ type: `${type}_REJECTED`, payload: dAppErrorMessage(err.message.split('\n')[0]) });
+              return reject(dAppErrorMessage(err.message.split('\n')[0]));
             });
         });
       } else {

--- a/src/actions/testQuery.js
+++ b/src/actions/testQuery.js
@@ -13,8 +13,8 @@ export function testQuery(
         web3.eth.getCoinbase((error, coinbase) => {
           if (error) {
             console.error(error);
-            dispatch({ type: `${type}_REJECTED`, payload: error });
-            return reject(error);
+            dispatch({ type: `${type}_REJECTED`, payload: error.message.split('\n')[0] });
+            return reject(error.message.split('\n')[0]);
           }
 
           console.log('Attempting to submit test query from ' + coinbase);

--- a/src/actions/testQuery.js
+++ b/src/actions/testQuery.js
@@ -1,4 +1,4 @@
-import { dAppErrorMessage } from '../util/utils';
+import { getMetamaskError } from '../util/utils';
 
 export function testQuery(
   { web3, querySpecs },
@@ -15,8 +15,8 @@ export function testQuery(
         web3.eth.getCoinbase((error, coinbase) => {
           if (error) {
             console.error(error);
-            dispatch({ type: `${type}_REJECTED`, payload: dAppErrorMessage(error.message.split('\n')[0]) });
-            return reject(dAppErrorMessage(error.message.split('\n')[0]));
+            dispatch({ type: `${type}_REJECTED`, payload: getMetamaskError(error.message.split('\n')[0]) });
+            return reject(getMetamaskError(error.message.split('\n')[0]));
           }
 
           console.log('Attempting to submit test query from ' + coinbase);
@@ -65,8 +65,8 @@ export function testQuery(
                         resolve(queryResults);
                       })
                       .catch(err => {
-                        dispatch({ type: `${type}_REJECTED`, payload: dAppErrorMessage(err.message.split('\n')[0]) });
-                        reject(dAppErrorMessage(err.message.split('\n')[0]));
+                        dispatch({ type: `${type}_REJECTED`, payload: getMetamaskError(err.message.split('\n')[0]) });
+                        reject(getMetamaskError(err.message.split('\n')[0]));
                       });
                   }
                 });
@@ -74,8 +74,8 @@ export function testQuery(
             .catch(err => {
               // catch errors during query submission
               console.error(err);
-              dispatch({ type: `${type}_REJECTED`, payload: dAppErrorMessage(err.message.split('\n')[0]) });
-              return reject(dAppErrorMessage(err.message.split('\n')[0]));
+              dispatch({ type: `${type}_REJECTED`, payload: getMetamaskError(err.message.split('\n')[0]) });
+              return reject(getMetamaskError(err.message.split('\n')[0]));
             });
         });
       } else {

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -229,9 +229,9 @@ class Order {
  * Fallback: return original message.
  *
  * @param errorMessage
- * @return dAppErrorMessage
+ * @return getMetamaskError
  */
-export const dAppErrorMessage = function (message) {
+export const getMetamaskError = function (message) {
   if (message.indexOf('User denied transaction') !== -1)
     return 'User denied transaction';
   else

--- a/src/util/utils.js
+++ b/src/util/utils.js
@@ -224,3 +224,16 @@ class Order {
 
 }
 
+/**
+ * Convert MetaMask error message to dApp error message.
+ * Fallback: return original message.
+ *
+ * @param errorMessage
+ * @return dAppErrorMessage
+ */
+export const dAppErrorMessage = function (message) {
+  if (message.indexOf('User denied transaction') !== -1)
+    return 'User denied transaction';
+  else
+    return message;
+};

--- a/test/actions/deploy.test.js
+++ b/test/actions/deploy.test.js
@@ -7,7 +7,7 @@ import { MarketContractRegistry, MarketContract, MarketCollateralPool, MarketTok
 import { deployContract } from '../../src/actions/deploy';
 
 function validContractSpecs() {
-  return { 
+  return {
     contractName: 'UNIT/TEST',
     priceFloor: 200,
     priceCap: 300,
@@ -39,11 +39,11 @@ describe('DeployAction', () => {
   }
 
   beforeEach(() => {
-    contractParams = { 
+    contractParams = {
       MarketContractRegistry: MarketContractRegistry(),
-      MarketContract: MarketContract(), 
-      MarketCollateralPool: MarketCollateralPool(), 
-      MarketToken: MarketToken() 
+      MarketContract: MarketContract(),
+      MarketCollateralPool: MarketCollateralPool(),
+      MarketToken: MarketToken()
     };
     deployParams = { contractSpecs: validContractSpecs(), web3: mockedCoinbaseWeb3() };
     dispatchSpy = sinon.spy();
@@ -74,7 +74,7 @@ describe('DeployAction', () => {
         expect(dispatchSpy).to.have.property('callCount', 2);
         expect(dispatchSpy.args[0][0].type).to.equals('DEPLOY_CONTRACT_PENDING');
         expect(dispatchSpy.args[1][0].type).to.equals('DEPLOY_CONTRACT_REJECTED');
-        expect(dispatchSpy.args[1][0].payload).to.equals(notDeployedError);
+        expect(dispatchSpy.args[1][0].payload).to.equals('MarketToken not deployed');
       });
   });
 

--- a/test/util/utils.test.js
+++ b/test/util/utils.test.js
@@ -1,14 +1,14 @@
 import { expect } from 'chai';
 
-import { dAppErrorMessage } from '../../src/util/utils';
+import { getMetamaskError } from '../../src/util/utils';
 
-describe('dAppErrorMessage', () => {
+describe('getMetamaskError', () => {
 
   it('should return "User denied transaction" for declined MetaMask transactions', async () => {
     const expectedErrorMessage = 'User denied transaction';
 
     const actualErrorMessage =
-      dAppErrorMessage('Error: MetaMask Tx Signature: User denied transaction signature.');
+      getMetamaskError('Error: MetaMask Tx Signature: User denied transaction signature.');
 
     expect(actualErrorMessage).to.equals(expectedErrorMessage);
   });
@@ -17,7 +17,7 @@ describe('dAppErrorMessage', () => {
     const expectedErrorMessage = 'Error: MetaMask Tx Signature: User denied signature.';
 
     const actualErrorMessage =
-      dAppErrorMessage('Error: MetaMask Tx Signature: User denied signature.');
+      getMetamaskError('Error: MetaMask Tx Signature: User denied signature.');
 
     expect(actualErrorMessage).to.equals(expectedErrorMessage);
   });

--- a/test/util/utils.test.js
+++ b/test/util/utils.test.js
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+
+import { dAppErrorMessage } from '../../src/util/utils';
+
+describe('dAppErrorMessage', () => {
+
+  it('should return "User denied transaction" for declined MetaMask transactions', async () => {
+    const expectedErrorMessage = 'User denied transaction';
+
+    const actualErrorMessage =
+      dAppErrorMessage('Error: MetaMask Tx Signature: User denied transaction signature.');
+
+    expect(actualErrorMessage).to.equals(expectedErrorMessage);
+  });
+
+  it('should return original error message as a fallback', async () => {
+    const expectedErrorMessage = 'Error: MetaMask Tx Signature: User denied signature.';
+
+    const actualErrorMessage =
+      dAppErrorMessage('Error: MetaMask Tx Signature: User denied signature.');
+
+    expect(actualErrorMessage).to.equals(expectedErrorMessage);
+  });
+
+})


### PR DESCRIPTION

##### Description
Errors thrown by MetaMask contain a summary and a detailed stack trace follows.
Pass only the summary to the error payload to be displayed in case an error occurs.

The change is quite safe. In case the error message consists of only one line, the full error message be shown.

##### Checklist

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
actions

##### Testing
Tested manually.

##### Refers/Fixes
Fixes: #116 