### PR TITLE
fix header logo sizing to prevent truncation

### DIFF
--- a/src/less/Header.less
+++ b/src/less/Header.less
@@ -42,7 +42,20 @@
 
 /* Medium screens */
 @media only screen and (min-width: 767px) and (max-width: 1042px) {
+    #logo {
+        padding-left: 10px;
+    }
     #logo img {
-        height: 30px;
+        height: 40px;
+    }
+    #nav {
+        font-size: 13px;
+        margin-right: 10px;
+    }
+    .ant-menu-submenu-title {
+        padding: 0 5px;
+    }
+    .ant-menu-item {
+        padding: 0 8px;
     }
 }

--- a/src/less/Header.less
+++ b/src/less/Header.less
@@ -41,7 +41,7 @@
 }
 
 /* Medium screens */
-@media only screen and (min-width: 40.063em) and (max-width: 64em) {
+@media only screen and (min-width: 767px) and (max-width: 1042px) {
     #logo img {
         height: 30px;
     }

--- a/src/less/Header.less
+++ b/src/less/Header.less
@@ -42,6 +42,9 @@
 
 /* Medium screens */
 @media only screen and (min-width: 767px) and (max-width: 1042px) {
+    .ant-menu-vertical .ant-menu-item {
+        font-size: 13px;
+    }
     #logo {
         padding-left: 10px;
     }


### PR DESCRIPTION
##### Description
This PR prevents logo truncation by updating media queries to rely on accurate absolute pixel widths. The design of the header could probably be further refined by keeping it at a single width and displaying only the most important items plus an overflow menu, but I've stayed within the scope of the issue.

##### Checklist

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
N/A

##### Testing
This is a simple CSS change, so I tested by opening in the latest Chrome, Firefox, and Safari.

##### Refers/Fixes
Fixes: #118