### PR TITLE
Add back button in case of error on test query or error on sumitting a contract

### DIFF
--- a/src/components/DeployContract/GuidedDeployment.js
+++ b/src/components/DeployContract/GuidedDeployment.js
@@ -56,6 +56,13 @@ class GuidedDeployment extends Component {
     });
   }
 
+  onFailSubmit() {
+    this.setState({
+      step: 0,
+      transitionDirection: 'prev'
+    });
+  }
+
   render() {
     const currentStep = this.state.step;
     const initialValues = this.props.initialValues;
@@ -95,9 +102,11 @@ class GuidedDeployment extends Component {
         }}
         showErrorMessage={showMessage.bind(showMessage, 'error')}
         showSuccessMessage={showMessage.bind(showMessage, 'success')}
+        onFailSubmit={this.onFailSubmit.bind(this)}
         loading={this.props.loading}
         contract={this.props.contract}
-        error={this.props.error}/>
+        error={this.props.error}
+        />
     ];
 
     return (

--- a/src/components/DeployContract/Steps.js
+++ b/src/components/DeployContract/Steps.js
@@ -322,24 +322,19 @@ class DeployStep extends BaseStepComponent {
               </a>
               </div>
             </div>}
-            {!this.props.loading && this.props.error && (
-              <div>
-              <Alert message={`${this.props.error}`} type="error" />
-              <Row style={{ padding: '30px'}} type="flex" justify="center">
-                <Col>
-                  <Button type="primary" onClick={this.props.onFailSubmit} >
-                    Try again
-                  </Button>
-                </Col>
-              </Row>
-              </div>
-          )}
+            {!this.props.loading && this.props.error &&
+              <Alert message={`${this.props.error}`} type="error" /> }
           </Card>
         </Col>
       </Row>
       <br/>
       <Row type="flex" justify="center">
         <Col>
+          {!this.props.loading && this.props.error && (
+            <Button type="primary" onClick={this.props.onFailSubmit} >
+              Try again
+            </Button>
+          )}
           {this.props.contract && <Link to="/contract/explorer"><Button type="primary">
             Explore All Contracts
           </Button>

--- a/src/components/DeployContract/Steps.js
+++ b/src/components/DeployContract/Steps.js
@@ -322,7 +322,18 @@ class DeployStep extends BaseStepComponent {
               </a>
               </div>
             </div>}
-            {!this.props.loading && this.props.error && <Alert message={`${this.props.error}`} type="error"/>}
+            {!this.props.loading && this.props.error && (
+              <div>
+              <Alert message={`${this.props.error}`} type="error" />
+              <Row style={{ padding: '30px'}} type="flex" justify="center">
+                <Col>
+                  <Button type="primary" onClick={this.props.onFailSubmit} >
+                    Try again
+                  </Button>
+                </Col>
+              </Row>
+              </div>
+          )}
           </Card>
         </Col>
       </Row>

--- a/src/components/TestQuery/Steps.js
+++ b/src/components/TestQuery/Steps.js
@@ -239,25 +239,20 @@ class QueryResultStep extends Component {
               </div>
             )}
             {!this.props.loading && !this.props.error && <p className="result">{this.props.result}</p>}
-            {!this.props.loading && this.props.error && (
-              <div>
-              <Alert message={`${this.props.error}`} type="error" />
-              <Row style={{ padding: '30px'}} type="flex" justify="center">
-                <Col>
-                  <Button type="primary" onClick={this.props.onFailSubmit} >
-                    Try again
-                  </Button>
-                </Col>
-              </Row>
-              </div>
-          )}
+            {!this.props.loading && this.props.error &&
+              <Alert message={`${this.props.error}`} type="error" /> }
           </Card>
         </Col>
       </Row>
       <br/>
-      {!this.props.loading && !this.props.error &&
       <Row type="flex" justify="center">
         <Col>
+          {!this.props.loading && this.props.error && (
+            <Button type="primary" onClick={this.props.onFailSubmit} >
+              Try again
+            </Button>
+          )}
+          {!this.props.loading && !this.props.error &&
           <ButtonGroup>
             <Button type="default" onClick={this.props.onPrevClicked} >
               <Icon type="left" />Test another query
@@ -265,9 +260,9 @@ class QueryResultStep extends Component {
             <Button type="primary" onClick={this.props.onCreateContractClicked} >
               Create contract with Query<Icon type="right" />
             </Button>
-          </ButtonGroup>
+          </ButtonGroup>}
         </Col>
-      </Row>}
+      </Row>
     </div>);
   }
 }

--- a/src/components/TestQuery/Steps.js
+++ b/src/components/TestQuery/Steps.js
@@ -239,7 +239,18 @@ class QueryResultStep extends Component {
               </div>
             )}
             {!this.props.loading && !this.props.error && <p className="result">{this.props.result}</p>}
-            {!this.props.loading && this.props.error && <Alert message={`${this.props.error}`} type="error" />}
+            {!this.props.loading && this.props.error && (
+              <div>
+              <Alert message={`${this.props.error}`} type="error" />
+              <Row style={{ padding: '30px'}} type="flex" justify="center">
+                <Col>
+                  <Button type="primary" onClick={this.props.onFailSubmit} >
+                    Try again
+                  </Button>
+                </Col>
+              </Row>
+              </div>
+          )}
           </Card>
         </Col>
       </Row>

--- a/src/components/TestQuery/TestQueryForm.js
+++ b/src/components/TestQuery/TestQueryForm.js
@@ -103,6 +103,13 @@ class TestQueryForm extends Component {
     });
   }
 
+  onFailSubmit() {
+    this.setState({
+      step: 0,
+      transitionDirection: 'prev'
+    });
+  }
+
   navigateToDeployContract() {
     const queryParams = {
       oracleDataSource: this.state.oracleDataSource,
@@ -142,7 +149,9 @@ class TestQueryForm extends Component {
         result={this.props.results}
         error={this.props.error}
         onPrevClicked={this.toPrevStep.bind(this)}
-        onCreateContractClicked={this.navigateToDeployContract.bind(this)} />,
+        onCreateContractClicked={this.navigateToDeployContract.bind(this)}
+        onFailSubmit={this.onFailSubmit.bind(this)}
+        />,
     ];
 
     return (

--- a/test/components/DeployContract/GuidedDeployment.test.js
+++ b/test/components/DeployContract/GuidedDeployment.test.js
@@ -62,6 +62,13 @@ describe('GuidedDeployment', () => {
     expect(guidedDeployment.find(DataSourceStep)).to.have.length(1);
   });
 
+  it('should reset to inital step', () => {
+    guidedDeployment.setState({step: deployStep});
+    guidedDeployment.setProps({error: "Without data"});
+    guidedDeployment.find(DeployStep).simulate('failSubmit');
+    expect(guidedDeployment.state('step')).to.equal(0);
+  });
+
   it('should called onDeployContract when DeployStep.deployContract', () => {
     guidedDeployment.setState({ step: deployStep });
     guidedDeployment.find(DeployStep).props().deployContract();

--- a/test/components/TestQuery/TestQueryForm.test.js
+++ b/test/components/TestQuery/TestQueryForm.test.js
@@ -87,9 +87,17 @@ describe('TestQueryForm', () => {
     expect(testQueryForm.find(QueryResultStep)).to.have.length(1);
   });
 
+  it('should reset to inital step', () => {
+    testQueryForm.setState({ step: queryResultStep});
+    testQueryForm.setProps({error: "Without data"});
+    testQueryForm.find(QueryResultStep).simulate('failSubmit');
+    expect(testQueryForm.state('step')).to.equal(0);
+
+  });
+
   it('should navigate to /contract/deploy onCreateContractClicked', () => {
     const navSpy = sinon.spy();
-    testQueryForm.setState({ 
+    testQueryForm.setState({
       step: queryResultStep,
       oracleDataSource: 'WolframAlpha',
       oracleQuery: '2+2'


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/MARKETProtocol/meta/blob/master/CONTRIBUTING.md
-->

##### Description
Add button to restart the process of test query in case of failure

##### Checklist

- [X] Changes don't break existing behavior

##### Testing
![dapp_return_button gif](https://user-images.githubusercontent.com/660973/39088418-0252ca3a-4577-11e8-81c1-549afc167230.gif)

Button with consistent design.
![dapp market protocol move button](https://user-images.githubusercontent.com/660973/39148609-5ae5028a-4702-11e8-8ac9-4dcbdb65e713.png)


##### Refers/Fixes
fixes #115
