### PR TITLE
Add overlay when 'quick deploy contract' is waiting for a response

### DIFF
--- a/src/components/DeployContract/QuickDeployment.js
+++ b/src/components/DeployContract/QuickDeployment.js
@@ -1,4 +1,4 @@
-import { Alert, Button, Col, Form, Row } from 'antd';
+import { Alert, Button, Col, Form, Row, Spin } from 'antd';
 import React, { Component } from 'react';
 
 import Loader from '../Loader';
@@ -8,11 +8,11 @@ import GasPriceField from '../GasPriceField';
 
 const formButtonLayout = {
   xs: {
-    span: 24,
+    span: 24
   },
   sm: {
     span: 8
-  },
+  }
 };
 
 const formItemColLayout = {
@@ -48,9 +48,10 @@ function ContractFormCol(props) {
  *
  */
 class QuickDeployment extends Component {
+
   componentWillReceiveProps(nextProps) {
-    if(this.props.loading && !nextProps.loading) {
-      if(nextProps.error) {
+    if (this.props.loading && !nextProps.loading) {
+      if (nextProps.error) {
         // We had an error
         this.props.showErrorMessage(`There was an error deploying the contract: ${nextProps.error}`, 8);
       } else if (nextProps.contract) {
@@ -83,7 +84,7 @@ class QuickDeployment extends Component {
   }
 
   isSubmitDisabled() {
-    if(this.props.loading) return true;
+    if (this.props.loading) return true;
 
     const errors = this.props.form.getFieldsError();
     return Object.keys(errors).some(field => errors[field]);
@@ -96,16 +97,18 @@ class QuickDeployment extends Component {
 
   render() {
     const { initialValues } = this.props;
-    return (
+
+    const quickForm = (
       <div>
         <Alert
-          style={{textAlign: 'center'}}
+          style={{ textAlign: 'center' }}
           banner
           type="info"
           showIcon={false}
           message={
             <span>
-              First time deploying a Contract? Try the <a className="switch-mode-link" href={this.props.guidedModeUrl} onClick={this.handleModeSwitching.bind(this)}>guided mode</a>.
+              First time deploying a Contract? Try the <a className="switch-mode-link" href={this.props.guidedModeUrl}
+                                                          onClick={this.handleModeSwitching.bind(this)}>guided mode</a>.
             </span>
           }
         />
@@ -117,37 +120,48 @@ class QuickDeployment extends Component {
               </ContractFormCol>
 
               <ContractFormCol>
-                <Field name='baseTokenAddress' initialValue={initialValues.baseTokenAddress} form={this.props.form} showHint/>
+                <Field name='baseTokenAddress' initialValue={initialValues.baseTokenAddress} form={this.props.form}
+                       showHint/>
               </ContractFormCol>
             </ContractFormRow>
 
             <ContractFormRow>
               <ContractFormCol>
-                <Field name='priceFloor' initialValue={isNaN(initialValues.priceFloor) ? '' : parseInt(initialValues.priceFloor, 10)} form={this.props.form} showHint/>
+                <Field name='priceFloor'
+                       initialValue={isNaN(initialValues.priceFloor) ? '' : parseInt(initialValues.priceFloor, 10)}
+                       form={this.props.form} showHint/>
               </ContractFormCol>
 
               <ContractFormCol>
-                <Field name='priceCap' initialValue={isNaN(initialValues.priceCap) ? '' : parseInt(initialValues.priceCap, 10)} form={this.props.form} showHint/>
-              </ContractFormCol>
-            </ContractFormRow>
-
-            <ContractFormRow>
-              <ContractFormCol>
-                <Field name='priceDecimalPlaces' initialValue={isNaN(initialValues.priceDecimalPlaces) ? '' : parseInt(initialValues.priceDecimalPlaces, 10)} form={this.props.form} showHint/>
-              </ContractFormCol>
-
-              <ContractFormCol>
-                <Field name="qtyMultiplier" initialValue={isNaN(initialValues.qtyMultiplier) ? '' : parseInt(initialValues.qtyMultiplier, 10)} form={this.props.form} showHint/>
+                <Field name='priceCap'
+                       initialValue={isNaN(initialValues.priceCap) ? '' : parseInt(initialValues.priceCap, 10)}
+                       form={this.props.form} showHint/>
               </ContractFormCol>
             </ContractFormRow>
 
             <ContractFormRow>
               <ContractFormCol>
-                <Field name='expirationTimeStamp' initialValue={initialValues.expirationTimeStamp} form={this.props.form} showHint/>
+                <Field name='priceDecimalPlaces'
+                       initialValue={isNaN(initialValues.priceDecimalPlaces) ? '' : parseInt(initialValues.priceDecimalPlaces, 10)}
+                       form={this.props.form} showHint/>
               </ContractFormCol>
 
               <ContractFormCol>
-                <Field name='oracleDataSource' initialValue={initialValues.oracleDataSource} form={this.props.form} showHint/>
+                <Field name="qtyMultiplier"
+                       initialValue={isNaN(initialValues.qtyMultiplier) ? '' : parseInt(initialValues.qtyMultiplier, 10)}
+                       form={this.props.form} showHint/>
+              </ContractFormCol>
+            </ContractFormRow>
+
+            <ContractFormRow>
+              <ContractFormCol>
+                <Field name='expirationTimeStamp' initialValue={initialValues.expirationTimeStamp}
+                       form={this.props.form} showHint/>
+              </ContractFormCol>
+
+              <ContractFormCol>
+                <Field name='oracleDataSource' initialValue={initialValues.oracleDataSource} form={this.props.form}
+                       showHint/>
               </ContractFormCol>
             </ContractFormRow>
 
@@ -159,13 +173,14 @@ class QuickDeployment extends Component {
 
             <ContractFormRow>
               <ContractFormCol>
-                <GasPriceField location={this.props.location} form={this.props.form} />
+                <GasPriceField location={this.props.location} form={this.props.form}/>
               </ContractFormCol>
             </ContractFormRow>
 
             <Row type="flex" justify="center">
               <Col {...formButtonLayout}>
-                <Button className="submit-button" type="primary" htmlType="submit" loading={this.props.loading} disabled={this.isSubmitDisabled()} style={{width: '100%'}}>
+                <Button className="submit-button" type="primary" htmlType="submit" loading={this.props.loading}
+                        disabled={this.isSubmitDisabled()} style={{ width: '100%' }}>
                   Deploy Contract
                 </Button>
               </Col>
@@ -173,18 +188,26 @@ class QuickDeployment extends Component {
 
             <Row type="flex" justify="center" style={{ marginTop: '16px' }}>
               <Col {...formButtonLayout}>
-                <Button className="reset-button" type="secondary" style={{width: '100%'}} disabled={this.props.loading} onClick={this.handleReset.bind(this)}>
+                <Button className="reset-button" type="secondary" style={{ width: '100%' }}
+                        disabled={this.props.loading} onClick={this.handleReset.bind(this)}>
                   Reset Form
                 </Button>
               </Col>
             </Row>
-
-            <Loader loading={this.props.loading} center={true}/>
           </Form>
         </div>
       </div>
     );
+
+    const loader = (<Loader loading={this.props.loading} center={true}/>);
+
+    return (this.props.loading ?
+        <Spin indicator={loader} style={{ maxHeight: '100%', height: '100%' }}>
+          {quickForm}
+        </Spin> : quickForm
+    );
   }
+
 }
 
 export default Form.create()(QuickDeployment);

--- a/src/less/App.less
+++ b/src/less/App.less
@@ -72,7 +72,12 @@ code {
     .ant-steps-item-process .ant-steps-item-icon > .ant-steps-icon {
         color: #000;
     }
-    .ant-pagination-disabled a, .ant-pagination-disabled:hover a, .ant-pagination-disabled:focus a, .ant-pagination-disabled .ant-pagination-item-link, .ant-pagination-disabled:hover .ant-pagination-item-link, .ant-pagination-disabled:focus .ant-pagination-item-link {
+    .ant-pagination-disabled a,
+    .ant-pagination-disabled:hover a,
+    .ant-pagination-disabled:focus a,
+    .ant-pagination-disabled .ant-pagination-item-link,
+    .ant-pagination-disabled:hover .ant-pagination-item-link,
+    .ant-pagination-disabled:focus .ant-pagination-item-link {
         border-color: #444444;
         color: #444444;
     }
@@ -81,7 +86,7 @@ code {
     }
     .ant-input-disabled {
         color: rgba(255, 255, 255, 0.45);
-    }    
+    }
     .ant-table-filter-dropdown {
         border: 1px solid @primary-color;
     }
@@ -117,6 +122,9 @@ code {
     .ant-popover-title {
         color: @body-background;
         border-bottom: 1px solid #adaeaf;
+    }
+    .ant-spin-blur {
+        opacity: 0.25;
     }
 }
 

--- a/test/components/DeployContract/QuickDeployment.test.js
+++ b/test/components/DeployContract/QuickDeployment.test.js
@@ -8,7 +8,7 @@ import moment from 'moment';
 import QuickDeployment from '../../../src/components/DeployContract/QuickDeployment';
 
 function validContractFields() {
-  return { 
+  return {
     contractName: { value: 'ABA' },
     baseTokenAddress: { value: '0x33333' },
     priceFloor: { value: 0 },
@@ -35,9 +35,9 @@ describe('QuickDeployment', () => {
     onDeploySpy = sinon.spy();
     successMessageSpy = sinon.spy();
     errorMessageSpy = sinon.spy();
-    quickDeployment = mount(<QuickDeployment 
-      initialValues={{}} 
-      switchMode={switchModeSpy} 
+    quickDeployment = mount(<QuickDeployment
+      initialValues={{}}
+      switchMode={switchModeSpy}
       showErrorMessage={errorMessageSpy}
       showSuccessMessage={successMessageSpy}
       onDeployContract={onDeploySpy}
@@ -108,9 +108,38 @@ describe('QuickDeployment', () => {
     expect(resetButton.prop('disabled')).to.equal(true);
   });
 
+  it('should show the overlay when loading', () => {
+    quickDeployment.setProps({
+      loading: true
+    });
+
+    const overlay = quickDeployment.find('.ant-spin');
+    expect(overlay).to.have.length(1);
+  });
+
+  it('should overlay dont hide on click', () => {
+    quickDeployment.setProps({
+      loading: true
+    });
+
+    quickDeployment.find('.ant-spin').simulate('click');
+
+    expect(quickDeployment.find('.ant-spin')).to.have.length(1);
+  });
+
+  it('should hide the overlay when is not loading', () => {
+    quickDeployment.setProps({
+      loading: false
+    });
+
+    const overlay = quickDeployment.find('.ant-spin');
+    expect(overlay).to.have.length(0);
+
+  });
+
   it('should reset form when .reset-button is clicked', () => {
     const defaultFieldValues = wrappedFormRef.props.form.getFieldsValue();
-    wrappedFormRef.props.form.setFields(validContractFields());    
+    wrappedFormRef.props.form.setFields(validContractFields());
     quickDeployment.setProps({
       loading: false
     });
@@ -124,7 +153,7 @@ describe('QuickDeployment', () => {
 
   it('should call onDeployContract with form values when submitted', () => {
     wrappedFormRef.props.form.setFields(validContractFields());
-    
+
     quickDeployment.find(Form).first().simulate('submit', { preventDefault() {} });
     expect(onDeploySpy).to.have.property('callCount', 1);
     // TODO: Test the values passed to onDeployContract


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/MARKETProtocol/meta/blob/master/CONTRIBUTING.md
-->

##### Description
Add an overlay while is waiting network response when one contract is deployed.

##### Checklist

- [X] Linter status: 100% pass
- [X] Changes don't break existing behavior
- [X] Tests coverage hasn't decreased


##### Testing
![test_overlay gif](https://user-images.githubusercontent.com/660973/39108168-6f38fe10-468c-11e8-8c9d-d804102243f9.gif)

##### Refers/Fixes
Fixes: #110