### PR TITLE
Ensure expiration timestamp cannot be more than 60 days from today

### DIFF
--- a/src/components/DeployContract/DeployContractField.js
+++ b/src/components/DeployContract/DeployContractField.js
@@ -238,11 +238,20 @@ const fieldSettingsByName = {
         validator: timestampValidator
       }
     ],
-    extra: 'Expiration timestamp for all open positions to settle.',
+    extra:
+      'Expiration timestamp for all open positions to settle. Cannot be more than 60 days from now.',
 
     component: () => (
       <DatePicker
         showTime
+        disabledDate={current => {
+          const now = moment().startOf('day');
+          return (
+            current &&
+            (current.isBefore(now, 'day') ||
+              current.startOf('day').diff(now, 'days') > 60)
+          );
+        }}
         format="YYYY-MM-DD HH:mm:ss"
         style={{ width: '100%' }}
       />

--- a/test/components/DeployContract/DeployContractForm.test.js
+++ b/test/components/DeployContract/DeployContractForm.test.js
@@ -70,6 +70,6 @@ describe('DeployContractForm', () => {
     });
     deployContractForm.find(QuickDeployment).props().switchMode('guided');
     expect(navSpy).to.have.property('callCount', 1);
-    // TODO: Test the actuall parameters pushed to history stack.
+    // TODO: Test the actual parameters pushed to history stack.
   });
 });

--- a/test/components/DeployContract/QuickDeployment.test.js
+++ b/test/components/DeployContract/QuickDeployment.test.js
@@ -137,6 +137,54 @@ describe('QuickDeployment', () => {
 
   });
 
+  it('should disable past dates in expiration date picker', () => {
+    const pastDate = moment().subtract(1, 'days').format('MMMM D, YYYY');
+    const currentDate = moment().format('MMMM D, YYYY');
+
+    quickDeployment.find('span#expirationTimeStamp input').simulate('click');
+
+    expect(
+      quickDeployment
+      .find('span#expirationTimeStamp')
+      .find(`td[title="${pastDate}"]`)
+      .find('.ant-calendar-date')
+      .prop('aria-disabled')
+    ).to.equal(true);
+
+    expect(
+      quickDeployment
+        .find('span#expirationTimeStamp')
+        .find(`td[title="${currentDate}"]`)
+        .find('.ant-calendar-date')
+        .prop('aria-disabled')
+    ).to.equal(false);
+  });
+
+  it('should disable dates more than 60 from today in expiration date picker', () => {
+    const invalidExpiryDate = moment().add(61, 'days').format('MMMM D, YYYY');
+    const validExpiryDate = moment().add(60, 'days').format('MMMM D, YYYY');
+
+    quickDeployment.find('span#expirationTimeStamp input').simulate('click');
+    quickDeployment.find('span#expirationTimeStamp').find('.ant-calendar-next-month-btn').simulate('click');
+    quickDeployment.find('span#expirationTimeStamp').find('.ant-calendar-next-month-btn').simulate('click');
+
+    expect(
+      quickDeployment
+        .find('span#expirationTimeStamp')
+        .find(`td[title="${invalidExpiryDate}"]`)
+        .find('.ant-calendar-date')
+        .prop('aria-disabled')
+    ).to.equal(true);
+
+    expect(
+      quickDeployment
+        .find('span#expirationTimeStamp')
+        .find(`td[title="${validExpiryDate}"]`)
+        .find('.ant-calendar-date')
+        .prop('aria-disabled')
+    ).to.equal(false);
+  });
+
   it('should reset form when .reset-button is clicked', () => {
     const defaultFieldValues = wrappedFormRef.props.form.getFieldsValue();
     wrappedFormRef.props.form.setFields(validContractFields());


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/MARKETProtocol/meta/blob/master/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->

Disables dates more than 60 days from today in the expiration date picker. Also disables past days as it doesn't make sense.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like Docs, UI, UX, Tests etc). -->
UI

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->

Performed QA to make sure it works as expected.

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->

Fixes #142 

