### PR TITLE
Added tag to welcome message modal that shows green(rinkeby)/red(not …

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,6 +29,7 @@ class App extends Component {
           <Footer className="footer">
             dApp ©2018 Created by
             <a
+              style={{ marginLeft: 4 }}
               href="https://marketprotocol.io"
               target="_blank"
               rel="noopener noreferrer"

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 import { Button, Col, Icon, Row } from 'antd';
 
-import withGAPageView from '../containers/GoogleAnalyticsTracker';
-
 // Images
 import main from '../img/header-illustration.svg';
 import explore from '../img/explore-contracts.svg';
@@ -17,7 +15,7 @@ import WelcomeMessage from './WelcomeMessage';
 // Styles
 import '../less/Landing.less';
 
-class Landing extends Component {
+class LandingComponent extends Component {
   render() {
     return (
       <div>
@@ -157,10 +155,10 @@ class Landing extends Component {
           </Col>
         </Row>
 
-        <WelcomeMessage />
+        <WelcomeMessage network={this.props.network} />
       </div>
     );
   }
 }
 
-export default withGAPageView(Landing);
+export default LandingComponent;

--- a/src/components/WelcomeMessage.js
+++ b/src/components/WelcomeMessage.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Button, Modal } from 'antd';
+import { Button, Modal, Icon } from 'antd';
 
 export const title = 'Welcome to the official MARKET Protocol dApp';
 
@@ -19,6 +19,43 @@ class WelcomeMessage extends Component {
       localStorage.setItem('showWelcomeMessage', false);
     }
   };
+
+  renderNetWorkStatus(network) {
+    let textStyle = {
+      position: 'absolute',
+      bottom: 10,
+      left: 16,
+      maxWidth: '50%',
+      display: 'flex',
+      alignItems: 'center'
+    };
+
+    let iconProps = {
+      style: {
+        marginRight: 10
+      }
+    };
+
+    const networkStatusText =
+      network === 'rinkeby'
+        ? `Connected to rinkeby`
+        : `Not connected to rinkeby.`;
+
+    if (network === 'rinkeby') {
+      textStyle = { ...textStyle, color: '#00FFE2' };
+      iconProps = { ...iconProps, type: 'check-circle-o' };
+    } else {
+      textStyle = { ...textStyle, color: '#FF0A0A' };
+      iconProps = { ...iconProps, type: 'close-circle-o' };
+    }
+
+    return (
+      <p className="network-status" style={textStyle}>
+        <Icon {...iconProps} />
+        {networkStatusText}
+      </p>
+    );
+  }
 
   render() {
     return (
@@ -76,6 +113,7 @@ class WelcomeMessage extends Component {
             </span>
           </li>
         </ul>
+        {this.renderNetWorkStatus(this.props.network)}
       </Modal>
     );
   }

--- a/src/containers/Landing.js
+++ b/src/containers/Landing.js
@@ -1,0 +1,24 @@
+import { connect } from 'react-redux';
+
+import LandingComponent from '../components/Landing';
+import withGAPageView from './GoogleAnalyticsTracker';
+
+import store from '../store';
+
+const mapStateToProps = state => {
+  const { network } = state.web3;
+
+  return {
+    network
+  };
+};
+
+const mapDispatchToProps = dispatch => {
+  return {};
+};
+
+const Landing = withGAPageView(
+  connect(mapStateToProps, mapDispatchToProps)(LandingComponent)
+);
+
+export default Landing;

--- a/src/containers/index.js
+++ b/src/containers/index.js
@@ -3,3 +3,4 @@ export { default as FindContainer } from './Find';
 export { default as ExplorerContainer } from './Explorer';
 export { default as SimExchangeContainer } from './SimExchange';
 export { default as TestQueryContainer } from './TestQuery';
+export { default as LandingContainer } from './Landing';

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,9 +1,8 @@
 import * as Containers from './containers';
-import Landing from './components/Landing';
 
 export const routes = [
   {
-    component: Landing,
+    component: Containers.LandingContainer,
     exact: true,
     path: '/'
   },

--- a/test/components/WelcomeMessage.test.js
+++ b/test/components/WelcomeMessage.test.js
@@ -1,15 +1,13 @@
-import React from "react";
-import { mount } from "enzyme";
-import { expect } from "chai";
+import React from 'react';
+import { mount, render } from 'enzyme';
+import { expect } from 'chai';
 
-import { Modal } from "antd";
+import { Modal, Icon, Tag } from 'antd';
 
-import WelcomeMessage, { title } from "../../src/components/WelcomeMessage";
-import ReactDOM from "react-dom";
+import WelcomeMessage, { title } from '../../src/components/WelcomeMessage';
+import ReactDOM from 'react-dom';
 
-
-describe("WelcomeMessage", () => {
-
+describe('WelcomeMessage', () => {
   let welcomeMessage;
 
   beforeEach(() => {
@@ -25,18 +23,38 @@ describe("WelcomeMessage", () => {
     ReactDOM.render(<WelcomeMessage />, div);
   });
 
-  it("should have exact title", () => {
-    expect(welcomeMessage.find(Modal).prop("title")).to.equal(title);
+  it('should have exact title', () => {
+    expect(welcomeMessage.find(Modal).prop('title')).to.equal(title);
   });
 
-  it("should be visible true", () => {
+  it('should be visible true', () => {
     welcomeMessage.setState({ visible: true });
-    expect(welcomeMessage.find(Modal).prop("visible")).to.equal(true);
+    expect(welcomeMessage.find(Modal).prop('visible')).to.equal(true);
   });
 
-  it("click proceed to dApp should hide the modal", () => {
+  it('click proceed to dApp should hide the modal', () => {
     $$('.ant-btn-primary')[0].click();
-    expect(welcomeMessage.find(Modal).prop("visible")).to.equal(false);
+    expect(welcomeMessage.find(Modal).prop('visible')).to.equal(false);
   });
 
+  describe('should render a label showing the network status', () => {
+    it('should render a label with green text and check Icon when connected to rinkeby', () => {
+      welcomeMessage.setState({ visible: true });
+      welcomeMessage.setProps({ network: 'rinkeby' });
+      expect(welcomeMessage.find('p.network-status').length).to.equal(1);
+      expect(
+        welcomeMessage.find('p.network-status').props().style.color
+      ).to.equal('#00FFE2');
+      expect(welcomeMessage.find(Icon).props().type).to.equal('check-circle-o');
+    });
+    it('should render a label with red text and "X" Icon when NOT connected to rinkeby', () => {
+      welcomeMessage.setState({ visible: true });
+      welcomeMessage.setProps({ network: 'unknown' });
+      expect(welcomeMessage.find('p.network-status').length).to.equal(1);
+      expect(
+        welcomeMessage.find('p.network-status').props().style.color
+      ).to.equal('#FF0A0A');
+      expect(welcomeMessage.find(Icon).props().type).to.equal('close-circle-o');
+    });
+  });
 });


### PR DESCRIPTION
…rinkeby) text label with a check(rinkeby)/X(not rinkeby) icon

<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/MARKETProtocol/meta/blob/master/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->
Lets the user know what network they are connected to as soon as they land on the MarketProtocol dApp: 
- Green w/ check for rinkeby
- Red w/ X for non-rinkeby

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like Docs, UI, UX, Tests etc). -->
UI, Tests

##### Screenshots (Optional) 
<!-- Please attach screenshots of all purposeful UI changes (before and after screens are recommended). -->
<img width="644" alt="screen shot 2018-05-17 at 8 24 36 pm" src="https://user-images.githubusercontent.com/8314590/40213023-919b3d32-5a10-11e8-8804-da3e4de6b046.png">
<img width="554" alt="screen shot 2018-05-17 at 8 25 54 pm" src="https://user-images.githubusercontent.com/8314590/40213024-91b4340e-5a10-11e8-89c1-34ff21507aec.png">


##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->
Updated WelcomeMessage tests accordingly

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->

Fixes #148  