### PR TITLE
Reduce JS bundle size by cherry picking lodash functions

### DIFF
--- a/src/components/SimExchange/TradeContainer.js
+++ b/src/components/SimExchange/TradeContainer.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react';
 import Form from './TradeComponents/form';
 import Table from './TradeComponents/table';
-import _ from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 
 import { Modal, Table as AntTable } from 'antd';
 
@@ -82,7 +82,7 @@ class Buy extends Component {
           </h3>
 
           <AntTable
-            rowKey={() => _.uniqueId('row')}
+            rowKey={() => uniqueId('row')}
             pagination={false}
             size="small"
             columns={columns}

--- a/src/components/SimExchange/WalletComponents/Form.js
+++ b/src/components/SimExchange/WalletComponents/Form.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import _ from 'lodash';
+import capitalize from 'lodash/capitalize';
 import { Form as AntForm, Input, Button } from 'antd';
 
 const FormItem = AntForm.Item;
@@ -45,7 +45,7 @@ class Form extends Component {
     } = form;
 
     const numberError = isFieldTouched('number') && getFieldError('number');
-    type = _.capitalize(type);
+    type = capitalize(type);
 
     return (
       <AntForm onSubmit={this.handleSubmit}>


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/MARKETProtocol/meta/blob/master/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->
We're importing the whole `lodash` library when we're only making use of a few functions from it.
The PR fixes the issue by modularly importing lodash functions as required.

###### Before

![screenshot from 2018-06-12 20-00-37](https://user-images.githubusercontent.com/7039523/41324730-e5c604da-6e7b-11e8-8cb5-ad51793edafb.png)

###### After
![screenshot from 2018-06-12 20-01-11](https://user-images.githubusercontent.com/7039523/41324733-e99856c6-6e7b-11e8-9516-8a5f898bea54.png)

The numbers are approximate but it is an improvement as we can clearly see.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased
