### PR TITLE
Remove presence validation of market contract address

### DIFF
--- a/src/components/FindContract/FindContractField.js
+++ b/src/components/FindContract/FindContractField.js
@@ -6,10 +6,6 @@ const FormItem = Form.Item;
 const getFieldSettings = validators => ({
   rules: [
     {
-      required: true,
-      message: 'Please enter MARKET contract address'
-    },
-    {
       validator: validators.ethAddressValidator
     }
   ]


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/MARKETProtocol/meta/blob/master/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->
Removes presence validation of Market Contract address field in Find contracts page as it is superfluous. I think it's sufficient to have a single `ethAddressValidator`. This is merely an enhancement as we don't want to display both "Please enter MARKET contract address" and "Invalid ETH address" error messages (see screenshot)

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

### Before

![image](https://user-images.githubusercontent.com/7039523/41936279-4f08f714-7952-11e8-8e0e-59f1b467772d.png)


### After

![image](https://user-images.githubusercontent.com/7039523/41936292-57076900-7952-11e8-9549-5c64e3239aef.png)
