### PR TITLE
Remove reset button in quick deployment form

### DIFF
--- a/src/components/DeployContract/QuickDeployment.js
+++ b/src/components/DeployContract/QuickDeployment.js
@@ -263,20 +263,6 @@ class QuickDeployment extends Component {
                 </Button>
               </Col>
             </Row>
-
-            <Row type="flex" justify="center" style={{ marginTop: '16px' }}>
-              <Col {...formButtonLayout}>
-                <Button
-                  className="reset-button"
-                  type="secondary"
-                  style={{ width: '100%' }}
-                  disabled={loading}
-                  onClick={this.handleReset.bind(this)}
-                >
-                  Reset Form
-                </Button>
-              </Col>
-            </Row>
           </Form>
         </div>
       </div>

--- a/test/components/DeployContract/QuickDeployment.test.js
+++ b/test/components/DeployContract/QuickDeployment.test.js
@@ -110,15 +110,6 @@ describe('QuickDeployment', () => {
     expect(submitButton.prop('disabled')).to.equal(false);
   });
 
-  it('should disable reset button when loading', () => {
-    quickDeployment.setProps({
-      loading: true
-    });
-
-    const resetButton = quickDeployment.find('.reset-button').first();
-    expect(resetButton.prop('disabled')).to.equal(true);
-  });
-
   it('should show the overlay when loading', () => {
     quickDeployment.setProps({
       loading: true
@@ -237,20 +228,6 @@ describe('QuickDeployment', () => {
     expect(
       quickDeployment.find('.ant-calendar-picker-input').prop('value')
     ).to.equal(dateFormated);
-  });
-
-  it('should reset form when .reset-button is clicked', () => {
-    const defaultFieldValues = wrappedFormRef.props.form.getFieldsValue();
-    wrappedFormRef.props.form.setFields(validContractFields());
-    quickDeployment.setProps({
-      loading: false
-    });
-
-    const resetButton = quickDeployment.find('.reset-button').first();
-    resetButton.simulate('click', { preventDefault() {} });
-
-    const valuesAfterReset = wrappedFormRef.props.form.getFieldsValue();
-    expect(valuesAfterReset).to.deep.equals(defaultFieldValues);
   });
 
   it('should call onDeployContract with form values when submitted', () => {


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/MARKETProtocol/meta/blob/master/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->
Removes 'Reset Form' button on Quick deployment form. Also removes the test related to it.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like Docs, UI, UX, Tests etc). -->
UX

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->

Fixes #217 