### PR TITLE
Extend Simplified Deploy to include Bitfinex API

### DIFF
--- a/src/components/DeployContract/SelectTokenField.js
+++ b/src/components/DeployContract/SelectTokenField.js
@@ -24,6 +24,7 @@ class SelectTokenField extends React.Component {
     };
     this.updateList = this.updateList.bind(this);
     this.handleSelect = this.handleSelect.bind(this);
+    this.onSelect = this.onSelect.bind(this);
   }
 
   componentWillReceiveProps(newProps) {
@@ -52,6 +53,18 @@ class SelectTokenField extends React.Component {
   handleSelect(e) {
     const exchange = getExchangeObj(this.props.exchange);
     const symbol = this.state.pairs[e];
+    if (exchange.getPrice) {
+      const onSelect = this.onSelect;
+      exchange.getPrice(symbol.symbol).subscribe(price => {
+        symbol.price = price;
+        onSelect(symbol, exchange);
+      });
+    } else {
+      this.onSelect(symbol, exchange);
+    }
+  }
+
+  onSelect(symbol, exchange) {
     this.props.onSelect({
       contractName: this.genContractName(symbol),
       symbolName: symbol.symbol,

--- a/test/components/DeployContract/SelectTokenField.test.js
+++ b/test/components/DeployContract/SelectTokenField.test.js
@@ -1,0 +1,92 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+import Rx from 'rxjs/Rx';
+
+import { Form, Select } from 'antd';
+import SelectTokenField from '../../../src/components/DeployContract/SelectTokenField';
+import ExchangeSources from '../../../src/components/DeployContract/ExchangeSources';
+
+let FormSelectTokenField = Form.create()(SelectTokenField);
+
+ExchangeSources.push({
+  key: 'TEX1',
+  name: 'TestExchange1',
+  genOracleQuery(symbol) {
+    return `json(https://api.test.com/v1/pubticker/${
+      symbol.symbol
+    }).last_price`;
+  },
+  fetchList(quotes) {
+    return Rx.Observable.from([
+      [{ symbol: 'ETHUSDT', priceDecimalPlaces: 5, quoteAsset: 'USDT' }]
+    ]);
+  }
+});
+
+ExchangeSources.push({
+  key: 'TEX2',
+  name: 'TestExchange2',
+  genOracleQuery(symbol) {
+    return `json(https://api.test.com/v1/pubticker/${
+      symbol.symbol
+    }).last_price`;
+  },
+  getPrice(symbol) {
+    return Rx.Observable.from([1]);
+  },
+  fetchList(quotes) {
+    return Rx.Observable.from([
+      [{ symbol: 'ETHUSDT', priceDecimalPlaces: 5, quoteAsset: 'USDT' }]
+    ]);
+  }
+});
+
+describe('SelectTokenField', () => {
+  let onSelectSpy;
+  beforeEach(() => {
+    onSelectSpy = sinon.spy();
+  });
+
+  it('should render a select', () => {
+    let selectTokenField = mount(
+      <FormSelectTokenField
+        name="tokenPair"
+        exchange="TEX1"
+        onSelect={onSelectSpy}
+      />
+    );
+    expect(selectTokenField.find(Select)).to.have.length(1);
+  });
+
+  it('should called onSelect when select (without getPrice)', () => {
+    let selectTokenField = mount(
+      <FormSelectTokenField
+        name="tokenPair"
+        exchange="TEX1"
+        onSelect={onSelectSpy}
+      />
+    );
+    selectTokenField
+      .find(Select)
+      .instance()
+      .props.onSelect(0);
+    expect(onSelectSpy).to.have.property('callCount', 1);
+  });
+
+  it('should called onSelect when select (with getPrice)', () => {
+    let selectTokenField = mount(
+      <FormSelectTokenField
+        name="tokenPair"
+        exchange="TEX2"
+        onSelect={onSelectSpy}
+      />
+    );
+    selectTokenField
+      .find(Select)
+      .instance()
+      .props.onSelect(0);
+    expect(onSelectSpy).to.have.property('callCount', 1);
+  });
+});


### PR DESCRIPTION
##### Description
- [x] Add ability for users to select Bitfinex as a source of settlement market data
- [x] Add all ETH and USD denominated pairs from Bitfinex
- [x] Structure oraclize queries based on bitfinex's api, ex: json(https://api.bitfinex.com/v2/ticker/tBTCUSD).7. Please see http://docs.oraclize.it/#general-concepts-query and https://github.com/dchester/jsonpath for details on creating a query. We currently support json only.
- [x] Create needed tests

##### Checklist
- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
Simplified Deploy

##### Screenshots (Optional) 
![screenshot from 2018-07-13 10-31-26](https://user-images.githubusercontent.com/4920000/42670992-1493e3e4-8688-11e8-8c66-044e6fe065c1.png)


##### Testing
Local

##### Refers/Fixes
Fixes: #229