### PR TITLE
Add Truffle-Migrate to docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,8 @@ WORKDIR /app
 
 RUN npm install -g truffle
 
-COPY package.json .
-RUN npm install
-
 COPY . .
+RUN npm install
 
 EXPOSE 3000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,3 +33,19 @@ services:
       - "3000:3000"
     depends_on:
       - truffle
+      - eth-bridge
+
+  truffle-migrate:
+    build: .
+    command: truffle migrate --reset --network=docker
+    volumes:
+      - ./build:/app/build
+      - ./contracts:/app/contracts
+      - ./migrations:/app/migrations
+    restart: unless-stopped
+    links:
+      - truffle
+    depends_on:
+      - truffle
+      - eth-bridge
+      - app

--- a/truffle.js
+++ b/truffle.js
@@ -13,6 +13,11 @@ module.exports = {
       from: '0x8a6C7Ea2C27827093825e5FdD57BD564312c6a2c',
       network_id: 4,
       gasPrice: 3000000000 // Specified in Wei
+    },
+    docker: {
+      host: 'truffle',
+      port: 9545,
+      network_id: '*' // Match any network id
     }
   }
 };


### PR DESCRIPTION
##### Description
This commit adds a new service to docker-compose which runs `truffle migrate` after the other services have been ran. This prevents errors in resolution of contracts and makes the overall
docker experience smooth and error free.

##### Checklist
- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
Docker

##### Refers/Fixes
Fixes: #283 
