### PR TITLE
fix issue #287 calendar initial value invalid type

### DIFF
--- a/src/components/DeployContract/Steps.js
+++ b/src/components/DeployContract/Steps.js
@@ -417,7 +417,7 @@ class ExpirationStep extends BaseStepComponent {
                   ? moment(expirationTimeStamp * 1000)
                   : isSimplified
                     ? moment().add(30, 'days')
-                    : ''
+                    : null
               }
               form={form}
               hideLabel


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/MARKETProtocol/meta/blob/master/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->
- This PR resolve a bug when calendar is initialized from DatePicker react component.
- I have passed `null` instead of empty string for resolve the issue.
- Maybe there are another methods to resolve it but i wanted to change as little as possible the logic.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Linter status: 100% pass
- [X] Changes don't break existing behavior
- [X] Tests coverage hasn't decreased

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like Docs, UI, UX, Tests etc). -->
Component Bug

##### Screenshots (Optional) 
<!-- Please attach screenshots of all purposeful UI changes (before and after screens are recommended). -->

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->
- I have tested this change in local, using Developer Branch.
- Mac OS 

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
Fixes: #287 