### PR TITLE
[Date Picker] Fixed issue selecting current day

### DIFF
--- a/src/components/DeployContract/DeployContractField.js
+++ b/src/components/DeployContract/DeployContractField.js
@@ -362,11 +362,11 @@ const fieldSettingsByName = {
         showTime
         disabledDate={current => {
           const now = moment().startOf('day');
-          return (
-            current &&
-            (current.valueOf() < moment().endOf('day') ||
-              current.diff(now, 'days') > 60)
-          );
+          return (current && (current.valueOf() < now || current.diff(now, 'days') > 60));
+        }}
+        onChange={selectedDate => {
+          const now = moment();
+          return (selectedDate.isSame(now, 'date') ? selectedDate.set(now.toObject()).add(30, 's') : selectedDate);
         }}
         showToday={false}
         format="YYYY-MM-DD HH:mm:ss"

--- a/src/components/DeployContract/DeployContractField.js
+++ b/src/components/DeployContract/DeployContractField.js
@@ -366,7 +366,7 @@ const fieldSettingsByName = {
         }}
         onChange={selectedDate => {
           const now = moment();
-          return (selectedDate.isSame(now, 'date') ? selectedDate.set(now.toObject()).add(30, 's') : selectedDate);
+          return (selectedDate.isSame(now, 'date') ? selectedDate.set(now.toObject()).add(60, 'm') : selectedDate);
         }}
         showToday={false}
         format="YYYY-MM-DD HH:mm:ss"

--- a/src/components/DeployContract/DeployContractField.js
+++ b/src/components/DeployContract/DeployContractField.js
@@ -366,7 +366,6 @@ const fieldSettingsByName = {
         }}
         onChange={selectedDate => {
           const now = moment();
-
           return (selectedDate && selectedDate.isSameOrBefore(now) ? selectedDate.set(now.toObject()).add(60, 'm') : selectedDate);
         }}
         showToday={false}

--- a/src/components/DeployContract/DeployContractField.js
+++ b/src/components/DeployContract/DeployContractField.js
@@ -366,7 +366,8 @@ const fieldSettingsByName = {
         }}
         onChange={selectedDate => {
           const now = moment();
-          return (selectedDate.isSame(now, 'date') ? selectedDate.set(now.toObject()).add(60, 'm') : selectedDate);
+
+          return (selectedDate && selectedDate.isSameOrBefore(now) ? selectedDate.set(now.toObject()).add(60, 'm') : selectedDate);
         }}
         showToday={false}
         format="YYYY-MM-DD HH:mm:ss"

--- a/src/components/SimExchange/Trade/Form.js
+++ b/src/components/SimExchange/Trade/Form.js
@@ -128,7 +128,7 @@ class BuyForm extends Component {
                 }}
                 onChange={selectedDate => {
                   const now = moment();
-                  return (selectedDate.isSame(now, 'date') ? selectedDate.set(now.toObject()).add(60, 'm') : selectedDate);
+                  return (selectedDate && selectedDate.isSameOrBefore(now) ? selectedDate.set(now.toObject()).add(60, 'm') : selectedDate);
                 }}
                 disabled={this.props.simExchange.contract === null}
                 showToday={false}

--- a/src/components/SimExchange/Trade/Form.js
+++ b/src/components/SimExchange/Trade/Form.js
@@ -124,11 +124,11 @@ class BuyForm extends Component {
                 showTime
                 disabledDate={current => {
                   const now = moment().startOf('day');
-                  return (
-                    current &&
-                    (current.valueOf() < moment().endOf('day') ||
-                      current.diff(now, 'days') > 60)
-                  );
+                  return (current && (current.valueOf() < now || current.diff(now, 'days') > 60));
+                }}
+                onChange={selectedDate => {
+                  const now = moment();
+                  return (selectedDate.isSame(now, 'date') ? selectedDate.set(now.toObject()).add(60, 'm') : selectedDate);
                 }}
                 disabled={this.props.simExchange.contract === null}
                 showToday={false}

--- a/test/components/DeployContract/QuickDeployment.test.js
+++ b/test/components/DeployContract/QuickDeployment.test.js
@@ -119,7 +119,7 @@ describe('QuickDeployment', () => {
     expect(overlay).to.have.length(0);
   });
 
-  it('should disable past dates in expiration date picker', () => {
+  it('should disable past dates in expiration date picker, but allow current date', () => {
     const pastDate = moment()
       .subtract(1, 'days')
       .format('MMMM D, YYYY');
@@ -144,7 +144,43 @@ describe('QuickDeployment', () => {
         .find(`td[title="${currentDate}"]`)
         .find('.ant-calendar-date')
         .prop('aria-disabled')
+    ).to.equal(false);
+
+    expect(
+      quickDeployment
+        .find('span#expirationTimeStamp')
+        .find(`td[title="${futureDate}"]`)
+        .find('.ant-calendar-date')
+        .prop('aria-disabled')
+    ).to.equal(false);
+  });
+
+  it('should disable past time on current date in expiration date picker', () => {
+    const pastTime = moment()
+      .subtract(60, 'minutes')
+      .format('HH:mm:ss');
+    const futureTime = moment()
+      .add(60, 'minutes')
+      .format('HH:mm:ss');
+    const currentDate = moment().format('HH:mm:ss');
+
+    quickDeployment.find('span#expirationTimeStamp input').simulate('click');
+
+    expect(
+      quickDeployment
+        .find('span#expirationTimeStamp')
+        .find(`td[title="${pastDate}"]`)
+        .find('.ant-calendar-date')
+        .prop('aria-disabled')
     ).to.equal(true);
+
+    expect(
+      quickDeployment
+        .find('span#expirationTimeStamp')
+        .find(`td[title="${currentDate}"]`)
+        .find('.ant-calendar-date')
+        .prop('aria-disabled')
+    ).to.equal(false);
 
     expect(
       quickDeployment

--- a/test/components/DeployContract/QuickDeployment.test.js
+++ b/test/components/DeployContract/QuickDeployment.test.js
@@ -162,14 +162,14 @@ describe('QuickDeployment', () => {
     const futureTime = moment()
       .add(60, 'minutes')
       .format('HH:mm:ss');
-    const currentDate = moment().format('HH:mm:ss');
+    const currentTime = moment().format('HH:mm:ss');
 
     quickDeployment.find('span#expirationTimeStamp input').simulate('click');
 
     expect(
       quickDeployment
         .find('span#expirationTimeStamp')
-        .find(`td[title="${pastDate}"]`)
+        .find(`td[title="${pastTimee}"]`)
         .find('.ant-calendar-date')
         .prop('aria-disabled')
     ).to.equal(true);
@@ -177,7 +177,7 @@ describe('QuickDeployment', () => {
     expect(
       quickDeployment
         .find('span#expirationTimeStamp')
-        .find(`td[title="${currentDate}"]`)
+        .find(`td[title="${currentTime}"]`)
         .find('.ant-calendar-date')
         .prop('aria-disabled')
     ).to.equal(false);
@@ -185,7 +185,7 @@ describe('QuickDeployment', () => {
     expect(
       quickDeployment
         .find('span#expirationTimeStamp')
-        .find(`td[title="${futureDate}"]`)
+        .find(`td[title="${futureTime}"]`)
         .find('.ant-calendar-date')
         .prop('aria-disabled')
     ).to.equal(false);

--- a/test/components/DeployContract/QuickDeployment.test.js
+++ b/test/components/DeployContract/QuickDeployment.test.js
@@ -155,40 +155,22 @@ describe('QuickDeployment', () => {
     ).to.equal(false);
   });
 
-  it('should disable past time on current date in expiration date picker', () => {
-    const pastTime = moment()
-      .subtract(60, 'minutes')
-      .format('HH:mm:ss');
-    const futureTime = moment()
-      .add(60, 'minutes')
-      .format('HH:mm:ss');
-    const currentTime = moment().format('HH:mm:ss');
+  it('should add 60 minutes to the time when the current date is selected', () => {
+    const dateSelected = moment().format('MMMM D, YYYY');
+    const currentDateFormated = moment().add(60, 'm').format('YYYY-MM-DD HH:mm:ss');
 
     quickDeployment.find('span#expirationTimeStamp input').simulate('click');
 
-    expect(
-      quickDeployment
-        .find('span#expirationTimeStamp')
-        .find(`td[title="${pastTimee}"]`)
-        .find('.ant-calendar-date')
-        .prop('aria-disabled')
-    ).to.equal(true);
+    quickDeployment
+      .find('span#expirationTimeStamp')
+      .find(`td[title="${dateSelected}"]`)
+      .simulate('click');
 
+    // Do to there being a little bit of lag from the moment the simulated click happens and the dateSelected
+    // variable receives it's value, we will expect the time to be valid up to the minute instead of second
     expect(
-      quickDeployment
-        .find('span#expirationTimeStamp')
-        .find(`td[title="${currentTime}"]`)
-        .find('.ant-calendar-date')
-        .prop('aria-disabled')
-    ).to.equal(false);
-
-    expect(
-      quickDeployment
-        .find('span#expirationTimeStamp')
-        .find(`td[title="${futureTime}"]`)
-        .find('.ant-calendar-date')
-        .prop('aria-disabled')
-    ).to.equal(false);
+      moment(quickDeployment.find('.ant-calendar-picker-input').prop('value')).format("HH:mm")
+    ).to.equal(moment(currentDateFormated).format('HH:mm'));
   });
 
   /*it('should disable dates more than 60 from today in expiration date picker', () => {
@@ -228,13 +210,8 @@ describe('QuickDeployment', () => {
   });*/
 
   it('should format the local date with utc', () => {
-    const dateSelected = moment()
-      .add(2, 'days')
-      .format('MMMM D, YYYY');
-
-    const dateFormated = moment()
-      .add(2, 'days')
-      .format('YYYY-MM-DD HH:mm:ss');
+    const dateSelected = moment().add(2, 'days').format('MMMM D, YYYY');
+    const dateFormated = moment().add(2, 'days').format('YYYY-MM-DD HH:mm:ss');
 
     quickDeployment.find('span#expirationTimeStamp input').simulate('click');
 
@@ -243,9 +220,11 @@ describe('QuickDeployment', () => {
       .find(`td[title="${dateSelected}"]`)
       .simulate('click');
 
+    // Do to there being a little bit of lag from the moment the simulated click happens and the dateSelected
+    // variable receives it's value, we will expect the time to be valid up to the minute instead of second
     expect(
-      quickDeployment.find('.ant-calendar-picker-input').prop('value')
-    ).to.equal(dateFormated);
+      moment(quickDeployment.find('.ant-calendar-picker-input').prop('value')).format("YYYY-MM-DD HH:mm")
+    ).to.equal(moment(dateFormated).format("YYYY-MM-DD HH:mm"));
   });
 
   it('should call onDeployContract with form values when submitted', () => {


### PR DESCRIPTION
##### Description
Simple changes to the DatePicker in both the DeploytContractField and SimExchange/Trade to allow the option to pick the current day for the expiration date.  When the current date is selected it will push the TimePicker pat of the DatePicker 60 minutes ahead so the user will not get a warning that the time is not valid.  

##### Checklist
- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
Ui/UX - DatePicker

##### Testing
I have tested this in my own development environment using the Rinkeby Test Network and submitted the results on a development server

##### Refers/Fixes
Fixes: https://github.com/MARKETProtocol/dApp/issues/300
