### PR TITLE
Hiding scrollbars in Simulated exchange page

### DIFF
--- a/src/components/SimExchange/OrderBook/Columns.js
+++ b/src/components/SimExchange/OrderBook/Columns.js
@@ -2,16 +2,19 @@ export default [
   {
     title: 'Qty',
     dataIndex: 'qty',
-    key: 'qty'
+    key: 'qty',
+    width: 80
   },
   {
     title: 'Price',
     dataIndex: 'price',
-    key: 'price'
+    key: 'price',
+    width: 100
   },
   {
     title: 'My Qty',
     dataIndex: 'myqty',
-    key: 'myqty'
+    key: 'myqty',
+    width: 80
   }
 ];

--- a/src/components/SimExchange/OrderBook/Orders.js
+++ b/src/components/SimExchange/OrderBook/Orders.js
@@ -53,15 +53,13 @@ class Orders extends Component {
     return (
       <div className="sim-ex-container">
         <SectionHeader name="Order Book" tooltip="This is your Order Book" />
-        <div className="sim-ex-inner-container" style={{ paddingTop: '0' }}>
-          <Table
-            rowKey={this.state.contract.key}
-            dataSource={this.state.bids}
-            columns={columns}
-            scroll={{ y: 600 }}
-            pagination={{ pageSize: 25 }}
-          />
-        </div>
+        <Table
+          rowKey={this.state.contract.key}
+          dataSource={this.state.bids}
+          columns={columns}
+          scroll={{ y: 700 }}
+          pagination={false}
+        />
       </div>
     );
   }

--- a/src/components/SimExchange/OrdersPositionsFills/Index.js
+++ b/src/components/SimExchange/OrdersPositionsFills/Index.js
@@ -23,9 +23,7 @@ class Index extends Component {
             }
             key="1"
           >
-            <div className="sim-ex-inner-container" style={{ paddingTop: '0' }}>
-              <OpenOrders />
-            </div>
+            <OpenOrders />
           </TabPane>
           <TabPane
             tab={
@@ -38,9 +36,7 @@ class Index extends Component {
             }
             key="2"
           >
-            <div className="sim-ex-inner-container" style={{ paddingTop: '0' }}>
-              <Positions />
-            </div>
+            <Positions />
           </TabPane>
           <TabPane
             tab={

--- a/src/components/SimExchange/OrdersPositionsFills/OpenOrders.js
+++ b/src/components/SimExchange/OrdersPositionsFills/OpenOrders.js
@@ -5,7 +5,14 @@ import openOrderColumns from './OpenOrderColumns';
 
 class OpenOrders extends Component {
   render() {
-    return <Table dataSource={[]} columns={openOrderColumns} />;
+    return (
+      <Table
+        dataSource={[]}
+        columns={openOrderColumns}
+        pagination={false}
+        scroll={{ y: 290 }}
+      />
+    );
   }
 }
 

--- a/src/components/SimExchange/OrdersPositionsFills/Positions.js
+++ b/src/components/SimExchange/OrdersPositionsFills/Positions.js
@@ -5,7 +5,14 @@ import positionsColumns from './PositionColumns';
 
 class Positions extends Component {
   render() {
-    return <Table dataSource={[]} columns={positionsColumns} />;
+    return (
+      <Table
+        dataSource={[]}
+        columns={positionsColumns}
+        pagination={false}
+        scroll={{ y: 350 }}
+      />
+    );
   }
 }
 

--- a/src/components/SimExchange/TradeHistory/Columns.js
+++ b/src/components/SimExchange/TradeHistory/Columns.js
@@ -2,12 +2,14 @@ export default [
   {
     title: 'Qty',
     dataIndex: 'qty',
-    key: 'qty'
+    key: 'qty',
+    width: 80
   },
   {
     title: 'Price',
     dataIndex: 'price',
-    key: 'price'
+    key: 'price',
+    width: 120
   },
   {
     title: 'Time',

--- a/src/components/SimExchange/TradeHistory/Trades.js
+++ b/src/components/SimExchange/TradeHistory/Trades.js
@@ -12,9 +12,12 @@ class Trades extends Component {
           name="Trade History"
           tooltip="This is the global Trading History"
         />
-        <div className="sim-ex-inner-container" style={{ paddingTop: '0' }}>
-          <Table dataSource={[]} columns={columns} />
-        </div>
+        <Table
+          dataSource={[]}
+          columns={columns}
+          pagination={false}
+          scroll={{ y: 700 }}
+        />
       </div>
     );
   }

--- a/src/components/SimExchange/Wallet.js
+++ b/src/components/SimExchange/Wallet.js
@@ -17,9 +17,7 @@ class Wallet extends Component {
             <HeaderMenu {...this.props} />
           </TabPane>
           <TabPane tab="History" key="2">
-            <div className="sim-ex-inner-container" style={{ paddingTop: '0' }}>
-              <Table {...this.props} />
-            </div>
+            <Table {...this.props} />
           </TabPane>
         </Tabs>
       </div>

--- a/src/components/SimExchange/Wallet/Table.js
+++ b/src/components/SimExchange/Wallet/Table.js
@@ -97,7 +97,12 @@ class BuyTable extends Component {
     return (
       <Fragment>
         <Row>
-          <Table dataSource={this.state.transactions} columns={columns} />
+          <Table
+            dataSource={this.state.transactions}
+            columns={columns}
+            pagination={false}
+            scroll={{ y: 250 }}
+          />
         </Row>
       </Fragment>
     );

--- a/src/less/SimExchange.less
+++ b/src/less/SimExchange.less
@@ -152,15 +152,14 @@
         font-size: 12px;
         color: #cccccc;
         font-weight: 300;
-        padding-top: 10px;
-        padding-bottom: 0px;
+        padding: 10px 0 15px 15px;
     }
 
     .ant-table-tbody > tr > td {
         background: #181e26;
         border-bottom: none;
-        padding-bottom: 0;
-        padding-top: 10px;
+        padding-bottom: 5px;
+        padding-top: 5px;
     }
 
     .info-icon {
@@ -170,6 +169,12 @@
         padding-left: 10px;
         font-weight: 300;
         font-size: 12px;
+        cursor: pointer;
+    }
+
+    // Hiding ugly default scrollbars in windows for webkit browsers
+    ::-webkit-scrollbar {
+        display: none;
     }
 }
 


### PR DESCRIPTION
<!--
  Thank you for your pull request. Please provide a description above and review
  the requirements below.

  Contributors guide: https://github.com/MARKETProtocol/meta/blob/master/CONTRIBUTING.md
-->

##### Description
<!-- A description on what this PR aims to solve -->
- Hiding scrollbars for WebKit browsers in sim exchange to fix showing up of defauly ugly scrollbars in windows and other environments
- Setting scroll height for tables
- Removed pagination numbers for tables

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s) (like Docs, UI, UX, Tests etc). -->
UI

##### Testing
<!-- Why should the PR reviewer trust that this change doesn't break anything? How have you tested this change? -->
Tested on windows chrome browser via browserstack

##### Refers/Fixes
<!--
  Link to an issue if applicable. For example:
  If your PR fixes an issue -- Fixes: #102
  If your PR refers an issue -- Refs: #101
-->
Fixes: #311 
