### PR TITLE
Deletes and replaces API WhitelistedAddress calls with Contracts path

### DIFF
--- a/src/actions/explorer.js
+++ b/src/actions/explorer.js
@@ -86,7 +86,7 @@ function loadContractsFromAPI(
   reject
 ) {
   marketAPI
-    .get(Path.WhitelistedContracts)
+    .get(Path.Contracts, { query: { whitelist: 1 } })
     .then(processContracts)
     .then(processedContracts => {
       dispatch({ type: `${type}_FULFILLED`, payload: processedContracts });

--- a/src/actions/explorer.js
+++ b/src/actions/explorer.js
@@ -6,7 +6,8 @@ import { Path } from '../util/marketAPI';
  * If the web3 parameter is set, the contracts are loaded from the blockchain,
  * else the marketAPI is used to load the contracts from the market-api service (which is faster).
  *
- * Typically, loading from web3 is used in the development environment.
+ * Typically, loading from web3 is used in the development environment (and should soon be deprecated
+ * in favour of a local market-api).
  *
  * @param processContracts function to process the loaded contract to a format required.
  * @param marketAPI The marketAPI resource used to interact with the server.

--- a/src/util/contracts.js
+++ b/src/util/contracts.js
@@ -1,3 +1,5 @@
+import { NULL_ADDRESS } from '../constants';
+
 export async function processContractsList(
   marketContract,
   marketCollateralPool,
@@ -11,7 +13,7 @@ export async function processContractsList(
       .then(async function(instance) {
         return await instance.MARKET_COLLATERAL_POOL_ADDRESS.call().then(
           async address => {
-            if (address !== '0x0000000000000000000000000000000000000000') {
+            if (address !== NULL_ADDRESS) {
               const contractJSON = {};
               contractJSON['key'] = instance.address;
               contractJSON[

--- a/src/util/contracts.js
+++ b/src/util/contracts.js
@@ -6,121 +6,103 @@ export async function processContractsList(
   deployedContracts
 ) {
   let promises = deployedContracts.map(async contract => {
-    if (
-      process.env.NODE_ENV === 'development' &&
-      localStorage.getItem(String(contract))
-    ) {
-      return JSON.parse(localStorage.getItem(String(contract)));
-    } else
-      return await marketContract
-        .at(contract)
-        .then(async function(instance) {
-          return await instance.MARKET_COLLATERAL_POOL_ADDRESS.call().then(
-            async address => {
-              if (address !== '0x0000000000000000000000000000000000000000') {
-                const contractJSON = {};
-                contractJSON['key'] = instance.address;
-                contractJSON[
-                  'CONTRACT_NAME'
-                ] = await instance.CONTRACT_NAME.call();
+    return await marketContract
+      .at(contract)
+      .then(async function(instance) {
+        return await instance.MARKET_COLLATERAL_POOL_ADDRESS.call().then(
+          async address => {
+            if (address !== '0x0000000000000000000000000000000000000000') {
+              const contractJSON = {};
+              contractJSON['key'] = instance.address;
+              contractJSON[
+                'CONTRACT_NAME'
+              ] = await instance.CONTRACT_NAME.call();
 
-                const collateralTokenContractAddress = await instance.COLLATERAL_TOKEN_ADDRESS.call();
-                contractJSON[
-                  'COLLATERAL_TOKEN_ADDRESS'
-                ] = collateralTokenContractAddress;
+              const collateralTokenContractAddress = await instance.COLLATERAL_TOKEN_ADDRESS.call();
+              contractJSON[
+                'COLLATERAL_TOKEN_ADDRESS'
+              ] = collateralTokenContractAddress;
 
-                await collateralToken
-                  .at(collateralTokenContractAddress)
-                  .then(async function(collateralTokenInstance) {
-                    contractJSON[
-                      'COLLATERAL_TOKEN'
-                    ] = await collateralTokenInstance.name();
-                    contractJSON[
-                      'COLLATERAL_TOKEN_SYMBOL'
-                    ] = await collateralTokenInstance.symbol();
-                  })
-                  .catch(function(err) {
-                    try {
-                      const token = contract(ERC20).at(
-                        collateralTokenContractAddress
-                      );
-                      contractJSON['COLLATERAL_TOKEN'] = token.name();
-                      contractJSON['COLLATERAL_TOKEN_SYMBOL'] = token.symbol();
-                    } catch (e) {
-                      console.error(e);
-                      contractJSON['COLLATERAL_TOKEN'] = 'NA';
-                      contractJSON['COLLATERAL_TOKEN_SYMBOL'] = 'NA';
-                    }
-                  });
+              await collateralToken
+                .at(collateralTokenContractAddress)
+                .then(async function(collateralTokenInstance) {
+                  contractJSON[
+                    'COLLATERAL_TOKEN'
+                  ] = await collateralTokenInstance.name();
+                  contractJSON[
+                    'COLLATERAL_TOKEN_SYMBOL'
+                  ] = await collateralTokenInstance.symbol();
+                })
+                .catch(function(err) {
+                  try {
+                    const token = contract(ERC20).at(
+                      collateralTokenContractAddress
+                    );
+                    contractJSON['COLLATERAL_TOKEN'] = token.name();
+                    contractJSON['COLLATERAL_TOKEN_SYMBOL'] = token.symbol();
+                  } catch (e) {
+                    console.error(e);
+                    contractJSON['COLLATERAL_TOKEN'] = 'NA';
+                    contractJSON['COLLATERAL_TOKEN_SYMBOL'] = 'NA';
+                  }
+                });
 
-                contractJSON[
-                  'PRICE_FLOOR'
-                ] = await instance.PRICE_FLOOR.call().then(data =>
-                  data.toNumber()
-                );
-                contractJSON[
-                  'PRICE_CAP'
-                ] = await instance.PRICE_CAP.call().then(data =>
-                  data.toNumber()
-                );
-                contractJSON[
-                  'PRICE_DECIMAL_PLACES'
-                ] = await instance.PRICE_DECIMAL_PLACES.call().then(data =>
-                  data.toNumber()
-                );
+              contractJSON[
+                'PRICE_FLOOR'
+              ] = await instance.PRICE_FLOOR.call().then(data =>
+                data.toNumber()
+              );
+              contractJSON['PRICE_CAP'] = await instance.PRICE_CAP.call().then(
+                data => data.toNumber()
+              );
+              contractJSON[
+                'PRICE_DECIMAL_PLACES'
+              ] = await instance.PRICE_DECIMAL_PLACES.call().then(data =>
+                data.toNumber()
+              );
 
-                contractJSON['MARKET_COLLATERAL_POOL_ADDRESS'] = address;
+              contractJSON['MARKET_COLLATERAL_POOL_ADDRESS'] = address;
 
-                contractJSON[
-                  'QTY_MULTIPLIER'
-                ] = await instance.QTY_MULTIPLIER.call().then(data =>
-                  data.toNumber()
-                );
-                contractJSON[
-                  'ORACLE_QUERY'
-                ] = await instance.ORACLE_QUERY.call();
-                contractJSON[
-                  'EXPIRATION'
-                ] = await instance.EXPIRATION.call().then(data =>
-                  data.toNumber()
-                );
-                contractJSON[
-                  'lastPrice'
-                ] = await instance.lastPrice
-                  .call()
-                  .then(data => data.toNumber());
-                contractJSON['isSettled'] = await instance.isSettled.call();
+              contractJSON[
+                'QTY_MULTIPLIER'
+              ] = await instance.QTY_MULTIPLIER.call().then(data =>
+                data.toNumber()
+              );
+              contractJSON['ORACLE_QUERY'] = await instance.ORACLE_QUERY.call();
+              contractJSON[
+                'EXPIRATION'
+              ] = await instance.EXPIRATION.call().then(data =>
+                data.toNumber()
+              );
+              contractJSON['lastPrice'] = await instance.lastPrice
+                .call()
+                .then(data => data.toNumber());
+              contractJSON['isSettled'] = await instance.isSettled.call();
 
-                // TODO: There is a possibility a contract ends up in our registry that wasn't linked to a collateral pool
-                // correctly.  The code below will handle this, but a better solution would probably to not actually
-                // display contracts that are not correctly linked to a collateral pool!
-                await marketCollateralPool
-                  .at(await address)
-                  .then(async function(collateralPoolInstance) {
-                    contractJSON[
-                      'collateralPoolBalance'
-                    ] = await collateralPoolInstance.collateralPoolBalance
-                      .call()
-                      .then(data => data.toNumber());
-                  })
-                  .catch(function(err) {
-                    console.error(err);
-                    contractJSON['collateralPoolBalance'] = 'NA';
-                  });
-                if (process.env.NODE_ENV === 'development') {
-                  localStorage.setItem(
-                    String(contract),
-                    JSON.stringify(contractJSON)
-                  );
-                }
-                return contractJSON;
-              }
+              // TODO: There is a possibility a contract ends up in our registry that wasn't linked to a collateral pool
+              // correctly.  The code below will handle this, but a better solution would probably to not actually
+              // display contracts that are not correctly linked to a collateral pool!
+              await marketCollateralPool
+                .at(await address)
+                .then(async function(collateralPoolInstance) {
+                  contractJSON[
+                    'collateralPoolBalance'
+                  ] = await collateralPoolInstance.collateralPoolBalance
+                    .call()
+                    .then(data => data.toNumber());
+                })
+                .catch(function(err) {
+                  console.error(err);
+                  contractJSON['collateralPoolBalance'] = 'NA';
+                });
+              return contractJSON;
             }
-          );
-        })
-        .catch(function(err) {
-          console.error(err);
-        });
+          }
+        );
+      })
+      .catch(function(err) {
+        console.error(err);
+      });
   });
 
   return await Promise.all(promises);

--- a/src/util/marketAPI.js
+++ b/src/util/marketAPI.js
@@ -1,11 +1,19 @@
+import qs from 'query-string';
+
 /**
  * Appends correct host to path
  *
  * @param {string} path
  */
-function url(path) {
+function url(path, query) {
   const host = 'https://dev.api.marketprotocol.io';
-  return `${host}${path}`;
+
+  const queryString = qs.stringify(query);
+  if (queryString === '') {
+    return `${host}${path}`;
+  } else {
+    return `${host}${path}${'?' + queryString}`;
+  }
 }
 
 export const marketAPI = {
@@ -14,11 +22,12 @@ export const marketAPI = {
    *
    * @param {string} path Path to request API
    * @param {function} fetch API fetch function defaults to fetch()
+   * @param {object} query Object containing query parameters for request
    * @param {bool} toJson Flag to convert result to
    * @return {Promise<*>} result of request
    */
-  get(path, { fetch = window.fetch, toJson = true } = {}) {
-    return fetch(url(path)).then(
+  get(path, { fetch = window.fetch, query = {}, toJson = true } = {}) {
+    return fetch(url(path, query)).then(
       response => (toJson ? response.json() : response)
     );
   }
@@ -27,6 +36,5 @@ export const marketAPI = {
 // paths to API resources
 export const Path = {
   Contracts: '/contracts',
-  WhitelistedContracts: '/contracts/whitelist',
   Orders: contractAddress => `/orders/${contractAddress}/`
 };

--- a/src/util/marketAPI.js
+++ b/src/util/marketAPI.js
@@ -9,11 +9,7 @@ function url(path, query) {
   const host = 'https://dev.api.marketprotocol.io';
 
   const queryString = qs.stringify(query);
-  if (queryString === '') {
-    return `${host}${path}`;
-  } else {
-    return `${host}${path}${'?' + queryString}`;
-  }
+  return host + path + (queryString !== '' ? `${'?' + queryString}` : '');
 }
 
 export const marketAPI = {

--- a/test/actions/explorer.test.js
+++ b/test/actions/explorer.test.js
@@ -94,7 +94,7 @@ describe('ExplorerAction', () => {
       mockMarketAPI
         .expects('get')
         .once()
-        .withArgs(Path.WhitelistedContracts)
+        .withArgs(Path.Contracts, { query: { whitelist: 1 } })
         .resolves(apiResponsePayload);
       deployParams.processContracts = processAPIContractsList;
 
@@ -112,7 +112,7 @@ describe('ExplorerAction', () => {
       mockMarketAPI
         .expects('get')
         .once()
-        .withArgs(Path.WhitelistedContracts)
+        .withArgs(Path.Contracts, { query: { whitelist: 1 } })
         .rejects('Fatal network error');
 
       return runLoadContractsAction().catch(() => {

--- a/test/util/marketAPI.test.js
+++ b/test/util/marketAPI.test.js
@@ -31,5 +31,16 @@ describe('marketAPI', () => {
           expect(response).to.equal(expectedResult);
         });
     });
+
+    it('should call fetch with url with query parameters', () => {
+      const query = { param: '1' };
+      spyFetch.resolves('{}');
+
+      return marketAPI
+        .get('/', { ...requestOptions, query })
+        .then(_response => {
+          expect(spyFetch.args[0][0]).contains('?param=1');
+        });
+    });
   });
 });


### PR DESCRIPTION
##### Description
This PR deprecates the get whitelisted address API and replaces it with the new API calls.

It also removes the caching done when loading transaction through web3 (no more needed)

##### Checklist

- [x] Linter status: 100% pass
- [x] Changes don't break existing behavior
- [x] Tests coverage hasn't decreased

##### Affected core subsystem(s)

MarketAPI

##### Refers/Fixes

Fixes: #332 